### PR TITLE
Adds ssb-server to omnia-relay

### DIFF
--- a/charts/omnia-relay/Chart.lock
+++ b/charts/omnia-relay/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: spire
   repository: https://chronicleprotocol.github.io/charts/
   version: 0.0.6
-digest: sha256:6f4dd7c831a88d6c8882bf3dc1d0a5b59aa8449635ebccdb7776757bca638650
-generated: "2023-05-25T15:16:04.739426092+02:00"
+- name: ssb-server
+  repository: https://chronicleprotocol.github.io/charts/
+  version: 0.0.1
+digest: sha256:607a057e271d5324bfd499fea89b3435ad485ab68d19988d2bcb74908e4e2f4d
+generated: "2023-05-31T11:15:14.765637021+02:00"

--- a/charts/omnia-relay/Chart.yaml
+++ b/charts/omnia-relay/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -34,3 +34,7 @@ dependencies:
     version: 0.0.6
     repository: https://chronicleprotocol.github.io/charts/
     condition: spire.enabled
+  - name: ssb-server
+    version: 0.0.1
+    repository: https://chronicleprotocol.github.io/charts/
+    condition: ssb-server.enabled

--- a/charts/omnia-relay/README.md
+++ b/charts/omnia-relay/README.md
@@ -1,6 +1,6 @@
 # omnia-relay
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
 
 A Helm chart for deploying an Omnia relay in Kubernetes
 
@@ -16,6 +16,7 @@ A Helm chart for deploying an Omnia relay in Kubernetes
 | Repository | Name | Version |
 |------------|------|---------|
 | https://chronicleprotocol.github.io/charts/ | spire | 0.0.6 |
+| https://chronicleprotocol.github.io/charts/ | ssb-server | 0.0.1 |
 
 ## Values
 
@@ -209,9 +210,27 @@ true
 		</tr>
 		<tr>
 			<td>omniaConfig.spireJson</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>omniaConfig.transports[0]</td>
 			<td>string</td>
 			<td><pre lang="json">
-"{\n  \"spire\": {\n    \"rpc\": {\n      \"address\": \"relay-spire:9100\"\n    },\n  }\n}"
+"ssb"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>omniaConfig.transports[1]</td>
+			<td>string</td>
+			<td><pre lang="json">
+"spire"
 </pre>
 </td>
 			<td></td>
@@ -428,6 +447,15 @@ true
 			<td>string</td>
 			<td><pre lang="json">
 "relay-tor-proxy"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>ssb-server.enabled</td>
+			<td>bool</td>
+			<td><pre lang="json">
+true
 </pre>
 </td>
 			<td></td>

--- a/charts/omnia-relay/templates/configmap.yaml
+++ b/charts/omnia-relay/templates/configmap.yaml
@@ -34,9 +34,11 @@ data:
         "ethGas": 200000,
         "chainType": "ethereum"
       },
-      "transports": [
-        "spire"
-      ],
+      {{- if .Values.omniaConfig.transports }}
+      "transports": {{ toJson .Values.omniaConfig.transports }},
+      {{ else }}
+      "transports": ["spire"],
+      {{- end }}
       {{- if .Values.omniaConfig.scuttlebotIdMap }}
       "scuttlebotIdMap": {
         {{- $keys := .Values.omniaConfig.scuttlebotIdMap | keys | sortAlpha }}
@@ -132,6 +134,9 @@ data:
       }
     }
   spire.json: |-
+    {{- if .Values.omniaConfig.spireJson }}
+    {{ .Values.omniaConfig.spireJson | nindent 4 }}
+    {{ else }}
     {
       "spire": {
         "rpc": {
@@ -139,3 +144,4 @@ data:
         },
       }
     }
+    {{- end }}

--- a/charts/omnia-relay/templates/deployment.yaml
+++ b/charts/omnia-relay/templates/deployment.yaml
@@ -61,12 +61,17 @@ spec:
           - name: password
             mountPath: /password/
           {{- end }}
+          - name: ssb-config
+            mountPath: /home/omnia/.ssb/
       volumes:
       - name: config
         configMap:
           name: {{ include "omnia-relay.fullname" . }}-config
       - name: omnia
         emptyDir: {}
+      - name: ssb-config
+        configMap:
+          name: {{ .Release.Name }}-ssb-server-config
       {{- if .Values.keystore.enabled }}
       {{- if .Values.keystore.existingSecret }}
       - name: keystore

--- a/charts/omnia-relay/values.yaml
+++ b/charts/omnia-relay/values.yaml
@@ -76,23 +76,21 @@ omniaConfig:
   #   BTC/USD: "0x586409bb88cF89BBAB0e106b0620241a0e4005c9"
   #   ETH/BTC: "0xaF495008d177a2E2AD95125b78ace62ef61Ed1f7"
   #   ETH/USD: "0xD81834Aa83504F6614caE3592fb033e4b8130380"
+
+  transports: ["ssb", "spire"]
+
   ### Can be used to override the default scuttlebotIdMap found as per https://github.com/chronicleprotocol/omnia-relay/blob/master/omnia/config/relay-ethereum-goerli.json#L29
   scuttlebotIdMap: []
   #   0x5C01f0F08E54B85f4CaB8C6a03c9425196fe66DD: "@uqOcvBdpBXWNCm5WhjALbtyR8szWpihH/CVyNdycncQ=.ed25519"
   #   0x75FBD0aaCe74Fb05ef0F6C0AC63d26071Eb750c9: "@wrrCKd56pV5CNSVh+fkVh6iaRUG6VA5I5VDEo8XOn5E=.ed25519"
   #   0x0c4FC7D66b7b6c684488c1F218caA18D4082da18: "@4ltZDRGFi4eHGGlXmLC8olcEs8XNZCXfvx+3V3S2HgY=.ed25519"
   #   0xC50DF8b5dcb701aBc0D6d1C7C99E6602171Abbc4: "@gt/2QK1AdSCLX3zRJQV6wRRsoxgohChCpjmNOOLUAA4=.ed25519"
-  spireJson: |-
-    {
-      "spire": {
-        "rpc": {
-          "address": "relay-spire:9100"
-        },
-      }
-    }
 
+  ## configure the omnia-relay spire.json if the default wont work for you
+  spireJson: {}
 
 # spire subchart configuration
+## add values from https://github.com/chronicleprotocol/charts/blob/main/charts/spire/values.yaml
 spire:
   enabled: true
   fullnameOverride: relay-spire
@@ -114,7 +112,8 @@ spire:
       CFG_LIBP2P_ENABLE: true
       CFG_WEBAPI_SOCKS5_PROXY_ADDR: "relay-tor-proxy:9050"
   configHcl: {}
-
+  ## tor-proxy is a subchart of spire
+  ## add values from https://github.com/chronicleprotocol/charts/blob/main/charts/tor-proxy/values.yaml
   tor-proxy:
     enabled: true
     fullnameOverride: relay-tor-proxy
@@ -135,3 +134,8 @@ spire:
           HiddenServiceDir /var/lib/tor/hidden_services
           HiddenServicePort 8888 relay-spire:8080
           HiddenServiceVersion
+
+## ssb subchart configuration
+ssb-server:
+  enabled: true
+  ## add values from https://github.com/chronicleprotocol/charts/blob/main/charts/ssb-server/values.yaml


### PR DESCRIPTION
Omnia relay chart, with ssb and spire transports enabled by default.

spire and ssb are subcharts of omnia-relay, and can be configured by values. they can also be disabled in values.yaml

tor is a subchart of spire, and can be configured through values.yaml as well 