### PR TITLE
use subpaths to mount keystore because of ethsign complaining

### DIFF
--- a/charts/omnia-relay/Chart.yaml
+++ b/charts/omnia-relay/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/omnia-relay/README.md
+++ b/charts/omnia-relay/README.md
@@ -1,6 +1,6 @@
 # omnia-relay
 
-![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.2](https://img.shields.io/badge/AppVersion-1.16.2-informational?style=flat-square)
+![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.2](https://img.shields.io/badge/AppVersion-1.16.2-informational?style=flat-square)
 
 A Helm chart for deploying an Omnia relay in Kubernetes
 
@@ -363,9 +363,9 @@ false
 		</tr>
 		<tr>
 			<td>omniaConfig.pairs[0].oracleSpread</td>
-			<td>float</td>
+			<td>int</td>
 			<td><pre lang="json">
-0.1
+1
 </pre>
 </td>
 			<td></td>
@@ -408,9 +408,9 @@ false
 		</tr>
 		<tr>
 			<td>omniaConfig.pairs[1].oracleSpread</td>
-			<td>float</td>
+			<td>int</td>
 			<td><pre lang="json">
-0.1
+1
 </pre>
 </td>
 			<td></td>

--- a/charts/omnia-relay/templates/deployment.yaml
+++ b/charts/omnia-relay/templates/deployment.yaml
@@ -28,15 +28,6 @@ spec:
       serviceAccountName: {{ include "omnia-relay.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      initContainers:
-        - name: init-container
-          image: busybox
-          command: ['sh', '-c', 'cp /getkeys/* /keystore']
-          volumeMounts:
-          - name: keystore
-            mountPath: /getkeys
-          - name: ethkeys
-            mountPath: /keystore
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -61,15 +52,17 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /config/omnia/
-          - name: ethkeys
-            mountPath: /keystore/
+          - name: keystore
+            mountPath: /keystore/keystore.json
+            subPath: keystore.json
+          - name: password
+            mountPath: /keystore/password.txt
+            subPath: password.txt
           {{- if index .Values "ssb-server" "enabled"}}
           - name: ssb-config
             mountPath: /home/omnia/.ssb/
           {{- end }}
       volumes:
-      - name: ethkeys
-        emptyDir: {}
       - name: config
         configMap:
           name: {{ include "omnia-relay.fullname" . }}-config
@@ -86,9 +79,12 @@ spec:
           items:
           - key: keystoreFile
             path: keystore.json
-          - key: password
+      - name: password
+        secret:
+          secretName: {{ .Values.keystore.existingSecret }}
+          items:
+          - key: password.txt
             path: password.txt
-          defaultMode: 0777
       {{- else }}
       - name: keystore
         configMap:
@@ -96,9 +92,12 @@ spec:
           items:
           - key: keystore.json
             path: keystore.json
+      - name: password
+        configMap:
+          name: {{ include "omnia-relay.fullname" . }}-keystore
+          items:
           - key: password.txt
             path: password.txt
-          defaultMode: 0777
       {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/omnia-relay/values.yaml
+++ b/charts/omnia-relay/values.yaml
@@ -103,12 +103,12 @@ omniaConfig:
       msgExpiration: 1800
       oracle: "0xe0F30cb149fAADC7247E953746Be9BbBB6B5751f"
       oracleExpiration: 86400
-      oracleSpread: 0.1
+      oracleSpread: 1
     - name: ETH/USD
       msgExpiration: 1800
       oracle: "0x64DE91F5A373Cd4c28de3600cB34C7C6cE410C85"
       oracleExpiration: 86400
-      oracleSpread: 0.1
+      oracleSpread: 1
 
   transports: ["spire"]
 


### PR DESCRIPTION

| Q                        | A
| ------------------------ | ---
| Service                  | omnia-relay
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | n/a
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |
| License                  | AGPL

### description of pull request:

- removes the init container for the keystore preperation
- mounts configmap/secret volumes using subPath, to remove the symlink stuff that breaks ethsign