### PR TITLE
tune ethGas in omnia via values

### DIFF
--- a/charts/omnia-relay/Chart.yaml
+++ b/charts/omnia-relay/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.9
+version: 0.0.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/omnia-relay/README.md
+++ b/charts/omnia-relay/README.md
@@ -320,7 +320,7 @@ false
 			<td>omniaConfig.ethGas</td>
 			<td>int</td>
 			<td><pre lang="json">
-700000
+200000
 </pre>
 </td>
 			<td></td>

--- a/charts/omnia-relay/README.md
+++ b/charts/omnia-relay/README.md
@@ -1,6 +1,6 @@
 # omnia-relay
 
-![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.2](https://img.shields.io/badge/AppVersion-1.16.2-informational?style=flat-square)
+![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.2](https://img.shields.io/badge/AppVersion-1.16.2-informational?style=flat-square)
 
 A Helm chart for deploying an Omnia relay in Kubernetes
 
@@ -95,7 +95,7 @@ false
 			<td>env.normal.ETH_CHAIN_TYPE</td>
 			<td>string</td>
 			<td><pre lang="json">
-"optimism"
+"ethereum"
 </pre>
 </td>
 			<td></td>
@@ -312,6 +312,15 @@ true
 			<td>bool</td>
 			<td><pre lang="json">
 false
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>omniaConfig.ethGas</td>
+			<td>int</td>
+			<td><pre lang="json">
+700000
 </pre>
 </td>
 			<td></td>

--- a/charts/omnia-relay/templates/configmap.yaml
+++ b/charts/omnia-relay/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
         "spireConfig": "",
         "srcTimeout": 10,
         "verbose": {{ .Values.omniaConfig.verbose | default true }},
-        "ethGas": 200000,
+        "ethGas": {{ .Values.omniaConfig.ethGas | default 200000 }},
         "chainType": "{{ .Values.omniaConfig.chainType }}"
       },
       {{- if .Values.omniaConfig.transports }}

--- a/charts/omnia-relay/values.yaml
+++ b/charts/omnia-relay/values.yaml
@@ -95,7 +95,7 @@ omniaConfig:
   debug: false
   verbose: true
   logFile: "json"
-  ethGas: 700000
+  ethGas: 200000
   ## must be one of "ethereum", "arbitrum" or "optimism"
   chainType: "ethereum"
   ### Can be used to over the default pairs mapping found as per https://github.com/chronicleprotocol/omnia-relay/blob/master/omnia/config/relay-ethereum-goerli.json#L35

--- a/charts/omnia-relay/values.yaml
+++ b/charts/omnia-relay/values.yaml
@@ -86,7 +86,7 @@ env:
     CFG_SPIRE_RPC_ADDR: relay-spire:9100
     CFG_FEEDS: prod
     ETH_RPC_URL: https://eth-mainnet.public.blastapi.io
-    ETH_CHAIN_TYPE: optimism
+    ETH_CHAIN_TYPE: ethereum
     OMNIA_MODE: relay
 
 omniaConfig:
@@ -95,6 +95,7 @@ omniaConfig:
   debug: false
   verbose: true
   logFile: "json"
+  ethGas: 700000
   ## must be one of "ethereum", "arbitrum" or "optimism"
   chainType: "ethereum"
   ### Can be used to over the default pairs mapping found as per https://github.com/chronicleprotocol/omnia-relay/blob/master/omnia/config/relay-ethereum-goerli.json#L35


### PR DESCRIPTION

| Q                        | A
| ------------------------ | ---
| Service                  | omnia-relay
| Fixed Issues?            | Allows for setting the ethGas param
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No
| License                  | AGPL

### description of pull request:

- adds `.Values.omniaConfig.ethGas` to be set
- if ommited, default of ` 200000` will be set