### PR TITLE
set imgage tags explicitly

### DIFF
--- a/charts/feed/Chart.yaml
+++ b/charts/feed/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/feed/README.md
+++ b/charts/feed/README.md
@@ -1,6 +1,6 @@
 # feed
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Feeds on Kubernetes
 
@@ -27,13 +27,16 @@ A Helm chart for deploying Chronicle Feeds on Kubernetes
 | ghost.enabled | bool | `true` |  |
 | ghost.env | object | `{}` |  |
 | ghost.ethConfig | object | `{}` |  |
+| ghost.image.tag | string | `"0.12.0-dev.3"` |  |
 | musig.enabled | bool | `true` |  |
 | musig.env | object | `{}` |  |
 | musig.ethConfig | object | `{}` |  |
+| musig.image.tag | string | `"0.1.1"` |  |
 | spire.bootstrap | bool | `true` |  |
 | spire.enabled | bool | `true` |  |
 | spire.env.normal.CFG_LIBP2P_BOOTSTRAP_ADDRS | string | `""` |  |
 | spire.env.normal.CFG_LIBP2P_PK_SEED | string | `""` |  |
+| spire.image.tag | string | `"0.12.0-dev.3"` |  |
 | spire.service.ports.libp2p.port | int | `8000` |  |
 | spire.service.ports.libp2p.protocol | string | `"TCP"` |  |
 | spire.service.type | string | `"ClusterIP"` |  |

--- a/charts/feed/values.yaml
+++ b/charts/feed/values.yaml
@@ -1,5 +1,7 @@
 spire:
   enabled: true
+  image:
+    tag: "0.12.0-dev.3"
   bootstrap: true
   service:
     type: ClusterIP
@@ -14,6 +16,8 @@ spire:
 
 ghost:
   enabled: true
+  image:
+    tag: "0.12.0-dev.3"
   ethConfig: {}
     # ethFrom:
     #   existingSecret: "eth-keys"
@@ -39,6 +43,8 @@ ghost:
 
 musig:
   enabled: true
+  image:
+    tag: "0.1.1"
   ethConfig: {}
     # ethFrom:
     #   existingSecret: "eth-keys"


### PR DESCRIPTION

| Q                        | A
| ------------------------ | ---
| Service                  | (ghost, spectre, musig)
| Fixed Issues?            | na
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR         | `[skip-ci]`
| Any Dependency Changes?  |
| License                  | AGPL

### description of pull request:

- by pulling subchart's `.Values.image.tag` into the top level, we can simply bump the image tags here, without needing to update the downstream subcharts.
- this will help with automatically testing / rolling out the new charts that are created
- simplify complexity of version hell