### PR TITLE
update default vaules for relay chart

### DIFF
--- a/charts/relay/Chart.lock
+++ b/charts/relay/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.0.6
 - name: spectre
   repository: https://chronicleprotocol.github.io/charts/
-  version: 0.1.7
-digest: sha256:bd157fd6515cf7f539f2e76f2f604801d3e1c86600e0323bac22d815cea486f6
-generated: "2023-08-17T14:45:03.373101391+02:00"
+  version: 0.1.8
+digest: sha256:5a643ea2386179fe401bca2d9b445a94a6dc4dc71ecee8b7340070bc52256e31
+generated: "2023-08-21T10:49:57.790791339+02:00"

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -34,6 +34,6 @@ dependencies:
     repository: https://chronicleprotocol.github.io/charts/
     condition: tor-proxy.enabled
   - name: spectre
-    version: 0.1.7
+    version: 0.1.8
     repository: https://chronicleprotocol.github.io/charts/
     condition: spectre.enabled

--- a/charts/relay/README.md
+++ b/charts/relay/README.md
@@ -15,7 +15,7 @@ A Helm chart for deploying Chronicle Relays on Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://chronicleprotocol.github.io/charts/ | spectre | 0.1.7 |
+| https://chronicleprotocol.github.io/charts/ | spectre | 0.1.8 |
 | https://chronicleprotocol.github.io/charts/ | tor-proxy | 0.0.6 |
 
 ## Values

--- a/charts/relay/README.md
+++ b/charts/relay/README.md
@@ -27,6 +27,7 @@ A Helm chart for deploying Chronicle Relays on Kubernetes
 | spectre.env.normal | object | `{}` |  |
 | spectre.ethConfig | object | `{}` |  |
 | spectre.fullnameOverride | string | `"spectre"` |  |
+| spectre.image.tag | string | `"sha-5e277a6"` |  |
 | tor-proxy.enabled | bool | `true` |  |
 | tor-proxy.env.normal.TOR_EXTRA_ARGS | string | `"AutomapHostsOnResolve 1\nControlSocketsGroupWritable 1\nCookieAuthentication 1\nCookieAuthFileGroupReadable 1\nDNSPort 5353\nExitPolicy reject *:*\nLog notice stderr\nRunAsDaemon 0\nControlSocket /home/tor/.tor/control_socket\nCookieAuthFile /home/tor/.tor/control_socket.authcookie\nDataDirectory /home/tor/.tor\nHiddenServiceDir /var/lib/tor/hidden_services\nHiddenServicePort 8888 spectre:8080\nHiddenServiceVersion 3\n"` |  |
 | tor-proxy.fullnameOverride | string | `"tor-proxy"` |  |

--- a/charts/relay/README.md
+++ b/charts/relay/README.md
@@ -1,6 +1,6 @@
 # relay
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Relays on Kubernetes
 
@@ -26,8 +26,9 @@ A Helm chart for deploying Chronicle Relays on Kubernetes
 | spectre.enabled | bool | `true` |  |
 | spectre.env.normal | object | `{}` |  |
 | spectre.ethConfig | object | `{}` |  |
+| spectre.fullnameOverride | string | `"spectre"` |  |
 | tor-proxy.enabled | bool | `true` |  |
-| tor-proxy.env.normal.TOR_EXTRA_ARGS | string | `"AutomapHostsOnResolve 1\nControlSocketsGroupWritable 1\nCookieAuthentication 1\nCookieAuthFileGroupReadable 1\nDNSPort 5353\nExitPolicy reject *:*\nLog notice stderr\nRunAsDaemon 0\nControlSocket /home/tor/.tor/control_socket\nCookieAuthFile /home/tor/.tor/control_socket.authcookie\nDataDirectory /home/tor/.tor\nHiddenServiceDir /var/lib/tor/hidden_services\nHiddenServicePort 8888 127.0.0.1:8080\nHiddenServiceVersion 3\n"` |  |
+| tor-proxy.env.normal.TOR_EXTRA_ARGS | string | `"AutomapHostsOnResolve 1\nControlSocketsGroupWritable 1\nCookieAuthentication 1\nCookieAuthFileGroupReadable 1\nDNSPort 5353\nExitPolicy reject *:*\nLog notice stderr\nRunAsDaemon 0\nControlSocket /home/tor/.tor/control_socket\nCookieAuthFile /home/tor/.tor/control_socket.authcookie\nDataDirectory /home/tor/.tor\nHiddenServiceDir /var/lib/tor/hidden_services\nHiddenServicePort 8888 spectre:8080\nHiddenServiceVersion 3\n"` |  |
 | tor-proxy.fullnameOverride | string | `"tor-proxy"` |  |
 | tor-proxy.torConfig | object | `{}` |  |
 

--- a/charts/relay/values.yaml
+++ b/charts/relay/values.yaml
@@ -1,5 +1,6 @@
 spectre:
   enabled: true
+  fullnameOverride: "spectre"
   ethConfig: {}
     # ethFrom:
     #   existingSecret: "eth-keys"
@@ -49,7 +50,7 @@ tor-proxy:
         CookieAuthFile /home/tor/.tor/control_socket.authcookie
         DataDirectory /home/tor/.tor
         HiddenServiceDir /var/lib/tor/hidden_services
-        HiddenServicePort 8888 127.0.0.1:8080
+        HiddenServicePort 8888 spectre:8080
         HiddenServiceVersion 3
   torConfig: {}
     # existingSecret: ""

--- a/charts/relay/values.yaml
+++ b/charts/relay/values.yaml
@@ -1,5 +1,7 @@
 spectre:
   enabled: true
+  image:
+    tag: "sha-5e277a6"
   fullnameOverride: "spectre"
   ethConfig: {}
     # ethFrom:
@@ -28,7 +30,6 @@ spectre:
       # CFG_ARB_CHAIN_ID: ${ARB_CHID} # arbitrum chain id
       # CFG_OPT_RPC_URLS: ${OPT_RPCS} # comma separated list of optimism rpc urls
       # CFG_OPT_CHAIN_ID: ${OPT_CHID} # optimism chain id
-
 
 tor-proxy:
   enabled: true


### PR DESCRIPTION


| Q                        | A
| ------------------------ | ---
| Service                  | spectre, tor-proxy
| Fixed Issues?            | no ticket
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR         | `[skip-ci]`
| Any Dependency Changes?  |
| License                  | AGPL

### description of pull request:

- makes more sane default values to make spinning up relays less bloated
