### PR TITLE
congifure tor entrypoint and allow additional ports"

### DIFF
--- a/charts/tor-proxy/Chart.yaml
+++ b/charts/tor-proxy/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: 0.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tor-proxy/README.md
+++ b/charts/tor-proxy/README.md
@@ -1,6 +1,6 @@
 # tor-proxy
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.7.10](https://img.shields.io/badge/AppVersion-0.4.7.10-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.7.10](https://img.shields.io/badge/AppVersion-0.4.7.10-informational?style=flat-square)
 
 A Helm chart for deploying tor-proxy to Kubernetes
 
@@ -20,7 +20,7 @@ A Helm chart for deploying tor-proxy to Kubernetes
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| env.normal.TOR_EXTRA_ARGS | string | `"AutomapHostsOnResolve 1\nControlSocketsGroupWritable 1\nCookieAuthentication 1\nCookieAuthFileGroupReadable 1\nDNSPort 5353\nExitPolicy reject *:*\nLog notice stderr\nRunAsDaemon 0\nControlSocket /home/tor/.tor/control_socket\nCookieAuthFile /home/tor/.tor/control_socket.authcookie\nDataDirectory /home/tor/.tor\nHiddenServiceDir /var/lib/tor/hidden_services\nHiddenServicePort 8888 127.0.0.1:8800\nHiddenServiceVersion 3\n"` |  |
+| env.normal.TOR_EXTRA_ARGS | string | `"ControlPort 127.0.0.1:9051\nSOCKSPort 0.0.0.0:9050\nAutomapHostsOnResolve 1\nControlSocketsGroupWritable 1\nCookieAuthentication 1\nCookieAuthFileGroupReadable 1\nDNSPort 5353\nExitPolicy reject *:*\nLog notice stderr\nRunAsDaemon 0\nControlSocket /home/tor/.tor/control_socket\nCookieAuthFile /home/tor/.tor/control_socket.authcookie\nDataDirectory /home/tor/.tor\nHiddenServiceDir /var/lib/tor/hidden_services\nHiddenServicePort 8888 127.0.0.1:8080\nHiddenServiceVersion 3\n"` |  |
 | extraObjects | list | `[]` | Extra K8s manifests to deploy |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -45,7 +45,8 @@ A Helm chart for deploying tor-proxy to Kubernetes
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
-| service.port | int | `9050` |  |
+| service.ports.socks.port | int | `9050` |  |
+| service.ports.socks.protocol | string | `"TCP"` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/tor-proxy/templates/configmap.yaml
+++ b/charts/tor-proxy/templates/configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tor-proxy.fullname" . }}-scripts
+data:
+  entrypoint.sh: |
+    #!/bin/sh
+    set -e
+
+    mkdir -p "$(dirname $TOR_CONFIG)"
+
+    mkdir -p "$TOR_DATA"
+    chown -R tor "$TOR_DATA"
+    chmod 700 "$TOR_DATA"
+
+    mkdir -p "/var/lib/tor/hidden_services"
+    chown -R tor /var/lib/tor/hidden_services
+    chmod 700 /var/lib/tor/hidden_services
+
+    cat <<-EOF > "$TOR_CONFIG"
+    ${TOR_EXTRA_ARGS}
+    EOF
+
+    if ! [ -z "${TOR_ADDITIONAL_CONFIG}" ]; then
+        echo "%include $TOR_ADDITIONAL_CONFIG" >> "$TOR_CONFIG"
+        echo "" >> "$TOR_ADDITIONAL_CONFIG"
+        echo "Added '%include $TOR_ADDITIONAL_CONFIG' to tor config"
+    fi
+
+    chown -R tor "$(dirname $TOR_CONFIG)"
+
+    if ! [ -z "${TOR_PASSWORD}" ]; then
+        TOR_PASSWORD_HASH="$(gosu tor tor --hash-password "$TOR_PASSWORD")"
+        echo "HashedControlPassword $TOR_PASSWORD_HASH" >> "$TOR_CONFIG"
+        echo "'HashedControlPassword $TOR_PASSWORD_HASH' added to tor config"
+    fi
+
+    exec gosu tor "$@"

--- a/charts/tor-proxy/templates/deployment.yaml
+++ b/charts/tor-proxy/templates/deployment.yaml
@@ -44,10 +44,13 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # command: ["sleep", "3600"]
           ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
-              protocol: TCP
+          {{- range $key, $val := .Values.service.ports }}
+            - name: {{ $key }}
+              containerPort: {{ $val.port }}
+              protocol: {{ $val.protocol }}
+          {{- end }}
           # livenessProbe:
           #   exec:
           #     command:
@@ -69,7 +72,18 @@ spec:
           volumeMounts:
             - name: tor-hidden-services
               mountPath: /var/lib/tor/hidden_services
+            - name: scripts-volume
+              mountPath: entrypoint.sh
+              subPath: entrypoint.sh
+
       volumes:
+        - name: scripts-volume
+          configMap:
+            name: {{ include "tor-proxy.fullname" . }}-scripts
+            items:
+            - key: entrypoint.sh
+              path: entrypoint.sh
+              mode: 0755
         {{- if .Values.torConfig }}
         - name: tor-keys
           secret:

--- a/charts/tor-proxy/templates/service.yaml
+++ b/charts/tor-proxy/templates/service.yaml
@@ -7,9 +7,11 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+    {{- range $key, $val := .Values.service.ports }}
+    - port: {{ $val.port }}
+      targetPort: {{ $val.port }}
+      protocol: {{ $val.protocol }}
+      name: {{ $key }}
+    {{- end }}
   selector:
     {{- include "tor-proxy.selectorLabels" . | nindent 4 }}

--- a/charts/tor-proxy/templates/tests/test-connection.yaml
+++ b/charts/tor-proxy/templates/tests/test-connection.yaml
@@ -8,11 +8,15 @@ metadata:
     "helm.sh/hook": test
 spec:
   containers:
-    - name: nc
+  {{- $serviceName := include "tor-proxy.fullname" . }}
+  {{- range $name, $config := .Values.service.ports }}
+    - name: nc-{{ $name }}
       image: busybox
       command: ['nc']
       args:
         - '-zv'
-        - '{{ include "tor-proxy.fullname" . }}'
-        - '{{ .Values.service.port }}'
+        - '-v'
+        - '{{ $serviceName }}'
+        - '{{ $config.port }}'
+  {{- end }}
   restartPolicy: Never

--- a/charts/tor-proxy/values.yaml
+++ b/charts/tor-proxy/values.yaml
@@ -38,7 +38,17 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 9050
+  ports:
+    socks:
+      port: 9050
+      protocol: TCP
+    ### to add more listeners for webapi, add them here
+    # hidden1:
+    #   port: 8888
+    #   protocol: TCP
+    # webapi:
+    #   port: 8080
+    #   protocol: TCP
 
 ingress:
   enabled: false
@@ -91,9 +101,11 @@ affinity: {}
 # Environment variable listing
 env:
   # non sensitive variables
-  # refer to https://github.com/chronicleprotocol/oracle-suite/tree/master/cmd/spire#environment-variables
+  # refer to https://manpages.debian.org/unstable/tor/tor.1.en.html#THE_CONFIGURATION_FILE_FORMAT
   normal:
     TOR_EXTRA_ARGS: |
+      ControlPort 127.0.0.1:9051
+      SOCKSPort 0.0.0.0:9050
       AutomapHostsOnResolve 1
       ControlSocketsGroupWritable 1
       CookieAuthentication 1
@@ -106,7 +118,7 @@ env:
       CookieAuthFile /home/tor/.tor/control_socket.authcookie
       DataDirectory /home/tor/.tor
       HiddenServiceDir /var/lib/tor/hidden_services
-      HiddenServicePort 8888 127.0.0.1:8800
+      HiddenServicePort 8888 127.0.0.1:8080
       HiddenServiceVersion 3
 torConfig: {}
   # existingSecret: "existingSecret"


### PR DESCRIPTION


| Q                        | A
| ------------------------ | ---
| Service                  | tor
| Fixed Issues?            | 
| Patch: Bug Fix?          | yes: allows configuring the entrypoint.sh 
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR         | `[skip-ci]`
| Any Dependency Changes?  |
| License                  | AGPL

### description of pull request:

- allows creation of addtional ports (might be useful to debug)
- allows configuring the entrypoint.sh script completely (as controlport and socks port was statically defined
