### PR TITLE
make more sensible configs for ghost and musig

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.12.0-dev.3"
+appVersion: "0.13.7"

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -1,6 +1,6 @@
 # ghost
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.0-dev.3](https://img.shields.io/badge/AppVersion-0.12.0--dev.3-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.7](https://img.shields.io/badge/AppVersion-0.13.7-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Ghost on Kubernetes
 
@@ -19,8 +19,11 @@ A Helm chart for deploying Chronicle Ghost on Kubernetes
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| chainId | string | `nil` |  |
 | env | object | `{}` |  |
+| ethChainId | string | `nil` |  |
 | ethConfig | object | `{}` |  |
+| ethRpcUrl | string | `nil` |  |
 | extraObjects | list | `[]` | Extra K8s manifests to deploy |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -42,6 +45,7 @@ A Helm chart for deploying Chronicle Ghost on Kubernetes
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| rpcUrl | string | `nil` |  |
 | securityContext | object | `{}` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -52,6 +52,22 @@ spec:
           #     path: /
           #     port: http
           env:
+          {{- if .Values.ethRpcUrl }}
+            - name: CFG_ETH_RPC_URLS
+              value: "{{ .Values.ethRpcUrl }}"
+          {{- end }}
+          {{- if .Values.ethChainId }}
+            - name: CFG_ETH_CHAIN_ID
+              value: "{{ .Values.ethChainId }}"
+          {{- end }}
+          {{- if .Values.rpcUrl }}
+            - name: CFG_RPC_URLS
+              value: "{{ .Values.rpcUrl }}"
+          {{- end }}
+          {{- if .Values.chainId }}
+            - name: CFG_CHAIN_ID
+              value: "{{ .Values.chainId }}"
+          {{- end }}
           {{- if .Values.ethConfig }}
             - name: CFG_ETH_FROM
               valueFrom:

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -10,6 +10,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+logLevel: null
+logFormat: null
+
 # Provide ETH keys from existing secrets
 # use only existing secret OR env vars, do not provide both
 ethConfig: {}
@@ -36,8 +39,17 @@ env: {}
   #   CFG_ETH_PASS: ""
   #   CFG_ETH_KEYS: ''
 
-logLevel: null
-logFormat: null
+# Environment variable listing
+
+# ethereum RPC client
+# exposes CFG_ETH_RPC_URLS, CFG_ETH_CHAIN_ID  as env vars
+ethRpcUrl: null
+ethChainId: null
+
+# default RPC client
+# exposes CFG_RPC_URLS, CFG_CHAIN_ID as env vars
+rpcUrl: null
+chainId: null
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/musig/Chart.yaml
+++ b/charts/musig/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.13.2"
+appVersion: "0.2.11"

--- a/charts/musig/README.md
+++ b/charts/musig/README.md
@@ -1,6 +1,6 @@
 # musig
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.2](https://img.shields.io/badge/AppVersion-0.13.2-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.11](https://img.shields.io/badge/AppVersion-0.2.11-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Musig on Kubernetes
 
@@ -20,16 +20,16 @@ A Helm chart for deploying Chronicle Musig on Kubernetes
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| command | list | `[]` |  |
 | env | object | `{}` |  |
 | ethChainId | string | `nil` |  |
 | ethConfig | object | `{}` |  |
+| ethRpcUrl | string | `nil` |  |
 | extraObjects | list | `[]` | Extra K8s manifests to deploy |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/chronicleprotocol/adria"` |  |
 | image.tag | string | `""` |  |
-| imagePullSecrets[0].name | string | `"ghcr-login-secret"` |  |
+| imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
@@ -37,6 +37,8 @@ A Helm chart for deploying Chronicle Musig on Kubernetes
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| logFormat | string | `nil` |  |
+| logLevel | string | `nil` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |

--- a/charts/musig/templates/deployment.yaml
+++ b/charts/musig/templates/deployment.yaml
@@ -32,7 +32,12 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          args: {{ .Values.command }}
+          args:
+            - "run"
+            - "-v"
+            - "{{ .Values.logLevel | default "debug" }}"
+            - "--log.format"
+            - "{{ .Values.logFormat | default "text" }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -50,6 +55,10 @@ spec:
           {{- if .Values.ethChainId }}
             - name: CFG_ETH_CHAIN_ID
               value: "{{ int .Values.ethChainId }}"
+          {{- end }}
+          {{- if .Values.ethRpcUrl }}
+            - name: CFG_RPC_URLS
+              value: "{{ .Values.ethRpcUrl }}"
           {{- end }}
           {{- if .Values.ethConfig }}
             - name: CFG_ETH_FROM

--- a/charts/musig/values.yaml
+++ b/charts/musig/values.yaml
@@ -10,7 +10,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-command: []
+logLevel: null
+logFormat: null
 
 # Provide ETH keys from existing secrets
 # use only existing secret OR env vars, do not provide both
@@ -24,16 +25,17 @@ ethConfig: {}
   # ethPass:
   #   existingSecret: ""
   #   key: ""
-# Environment variable listing
 
-# exposes CFG_ETH_CHAIN_ID as env var
+# Environment variable listing
+# exposes CFG_ETH_CHAIN_ID, CFG_RPC_URLS  as env vars
 ethChainId: null
+ethRpcUrl: null
 
 # non encrypted variables
 env: {}
   # refer to https://github.com/chronicleprotocol/musig/blob/master/docker-compose.yaml
   # normal:
-  #   CFG_ETH_KEYS: ''
+  #   CFG_RPC_URLS: 'https://eth.publicrpc.com'
   #   CFG_ETH_PASS: ""
   #   CFG_FEEDS: ""
   #   CFG_LIBP2P_BOOTSTRAP_ADDRS: "/dns4/bootstrap.local/tcp/8000/p2p/"
@@ -41,8 +43,7 @@ env: {}
   #   CFG_WEBAPI_ENABLE: 0
   #   CFG_MUSIG_SIGNERS_COUNT: 3
 
-imagePullSecrets:
-  - name: ghcr-login-secret
+imagePullSecrets: []
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
- allow configuring ethereum rpc url and chainID
- allow configuring default rpc urls and chainID
- standardize container args, and logLevel and LogFormat vals
