### PR TITLE
patch/libp2p networking

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.13.7"
+appVersion: "0.15.0"

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -1,6 +1,6 @@
 # ghost
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.7](https://img.shields.io/badge/AppVersion-0.13.7-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.0](https://img.shields.io/badge/AppVersion-0.15.0-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Ghost on Kubernetes
 
@@ -47,7 +47,8 @@ A Helm chart for deploying Chronicle Ghost on Kubernetes
 | resources | object | `{}` |  |
 | rpcUrl | string | `nil` |  |
 | securityContext | object | `{}` |  |
-| service.port | int | `80` |  |
+| service.ports.libp2p.port | int | `8000` |  |
+| service.ports.libp2p.protocol | string | `"TCP"` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/ghost/ci/ct-values.yaml
+++ b/charts/ghost/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+ethChainId: 1
+ethRpcUrl: 'https://eth.publicrpc.com'

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -40,9 +40,11 @@ spec:
             - "{{ .Values.logFormat | default "text" }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
-              protocol: TCP
+          {{- range $key, $val := .Values.service.ports }}
+            - name: {{ $key }}
+              containerPort: {{ $val.port }}
+              protocol: {{ $val.protocol }}
+          {{- end }}
           # livenessProbe:
           #   httpGet:
           #     path: /
@@ -52,6 +54,8 @@ spec:
           #     path: /
           #     port: http
           env:
+            - name: CFG_LIBP2P_LISTEN_ADDRS
+              value: "/ip4/0.0.0.0/tcp/{{ .Values.service.ports.libp2p.port | default 8000 }}"
           {{- if .Values.ethRpcUrl }}
             - name: CFG_ETH_RPC_URLS
               value: "{{ .Values.ethRpcUrl }}"

--- a/charts/ghost/templates/service.yaml
+++ b/charts/ghost/templates/service.yaml
@@ -7,9 +7,11 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+    {{- range $key, $val := .Values.service.ports }}
+    - port: {{ $val.port }}
+      targetPort: {{ $val.port }}
+      protocol: {{ $val.protocol }}
+      name: {{ $key }}
+    {{- end }}
   selector:
     {{- include "ghost.selectorLabels" . | nindent 4 }}

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -79,7 +79,14 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  ports:
+    libp2p:
+      port: 8000
+      protocol: TCP
+    ### to add more port-mappings, add them here:
+    # rpc:
+    #   port: 9100
+    #   protocol: TCP
 
 ingress:
   enabled: false

--- a/charts/musig/Chart.yaml
+++ b/charts/musig/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.11"
+appVersion: "0.4.0"

--- a/charts/musig/README.md
+++ b/charts/musig/README.md
@@ -1,6 +1,6 @@
 # musig
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.11](https://img.shields.io/badge/AppVersion-0.2.11-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Musig on Kubernetes
 
@@ -46,7 +46,10 @@ A Helm chart for deploying Chronicle Musig on Kubernetes
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
-| service.port | int | `8080` |  |
+| service.ports.libp2p.port | int | `8001` |  |
+| service.ports.libp2p.protocol | string | `"TCP"` |  |
+| service.ports.webapi.port | int | `8080` |  |
+| service.ports.webapi.protocol | string | `"TCP"` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/musig/ci/ct-values.yaml
+++ b/charts/musig/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+ethChainId: 1
+ethRpcUrl: 'https://eth.publicrpc.com'

--- a/charts/musig/templates/deployment.yaml
+++ b/charts/musig/templates/deployment.yaml
@@ -40,9 +40,11 @@ spec:
             - "{{ .Values.logFormat | default "text" }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
-              protocol: TCP
+          {{- range $key, $val := .Values.service.ports }}
+            - name: {{ $key }}
+              containerPort: {{ $val.port }}
+              protocol: {{ $val.protocol }}
+          {{- end }}
           # livenessProbe:
           #   httpGet:
           #     path: /
@@ -52,6 +54,8 @@ spec:
           #     path: /
           #     port: http
           env:
+            - name: CFG_LIBP2P_LISTEN_ADDRS
+              value: "/ip4/0.0.0.0/tcp/{{ .Values.service.ports.libp2p.port | default 8000 }}"
           {{- if .Values.ethChainId }}
             - name: CFG_ETH_CHAIN_ID
               value: "{{ int .Values.ethChainId }}"

--- a/charts/musig/templates/service.yaml
+++ b/charts/musig/templates/service.yaml
@@ -7,9 +7,11 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+    {{- range $key, $val := .Values.service.ports }}
+    - port: {{ $val.port }}
+      targetPort: {{ $val.port }}
+      protocol: {{ $val.protocol }}
+      name: {{ $key }}
+    {{- end }}
   selector:
     {{- include "musig.selectorLabels" . | nindent 4 }}

--- a/charts/musig/values.yaml
+++ b/charts/musig/values.yaml
@@ -72,7 +72,17 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8080
+  ports:
+    libp2p:
+      port: 8001
+      protocol: TCP
+    webapi:
+      port: 8080
+      protocol: TCP
+    ### to add more port-mappings, add them here:
+    # rpc:
+    #   port: 9100
+    #   protocol: TCP
 
 ingress:
   enabled: false


### PR DESCRIPTION
- chore(ghost): specify ports for libp2p
- chore(charts): :tshirt: lint and docs



| Q                        | A
| ------------------------ | ---
| Service                  | ghost & musig
| Fixed Issues?            | `Fixes #1, Fixes #2`
| Patch: Bug Fix?          | patch: service resources
| Major: Breaking Change?  | 
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | `[skip-ci]`
| Any Dependency Changes?  |
| License                  | AGPL

### description of pull request:
 
- allows configuring libp2p services for ghost and musig
- adds `CFG_LIBP2P_LISTEN_ADDRS` to both ghost and musig
