### PR TITLE
prep ghost/musig subcharts

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.15.0"
+appVersion: "0.17"

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -1,6 +1,6 @@
 # ghost
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.0](https://img.shields.io/badge/AppVersion-0.15.0-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17](https://img.shields.io/badge/AppVersion-0.17-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Ghost on Kubernetes
 

--- a/charts/ghost/ci/ct-values.yaml
+++ b/charts/ghost/ci/ct-values.yaml
@@ -1,2 +1,3 @@
 ethChainId: 1
 ethRpcUrl: 'https://eth.publicrpc.com'
+logLevel: "debug"

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -54,8 +54,12 @@ spec:
           #     path: /
           #     port: http
           env:
-            - name: CFG_LIBP2P_LISTEN_ADDRS
-              value: "/ip4/0.0.0.0/tcp/{{ .Values.service.ports.libp2p.port | default 8000 }}"
+          {{- if eq .Values.service.type "LoadBalancer" }}
+            - name: CFG_LIBP2P_EXTERNAL_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          {{- end }}
           {{- if .Values.ethRpcUrl }}
             - name: CFG_ETH_RPC_URLS
               value: "{{ .Values.ethRpcUrl }}"

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -39,6 +39,7 @@ env: {}
   #   CFG_ETH_PASS: ""
   #   CFG_ETH_KEYS: ''
 
+
 # Environment variable listing
 
 # ethereum RPC client

--- a/charts/musig/Chart.yaml
+++ b/charts/musig/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.0"
+appVersion: "0.7"

--- a/charts/musig/README.md
+++ b/charts/musig/README.md
@@ -1,6 +1,6 @@
 # musig
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7](https://img.shields.io/badge/AppVersion-0.7-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Musig on Kubernetes
 

--- a/charts/musig/ci/ct-values.yaml
+++ b/charts/musig/ci/ct-values.yaml
@@ -1,2 +1,3 @@
 ethChainId: 1
 ethRpcUrl: 'https://eth.publicrpc.com'
+logLevel: 'debug'

--- a/charts/musig/templates/deployment.yaml
+++ b/charts/musig/templates/deployment.yaml
@@ -54,8 +54,12 @@ spec:
           #     path: /
           #     port: http
           env:
-            - name: CFG_LIBP2P_LISTEN_ADDRS
-              value: "/ip4/0.0.0.0/tcp/{{ .Values.service.ports.libp2p.port | default 8000 }}"
+          {{- if eq .Values.service.type "LoadBalancer" }}
+            - name: CFG_LIBP2P_EXTERNAL_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          {{- end }}
           {{- if .Values.ethChainId }}
             - name: CFG_ETH_CHAIN_ID
               value: "{{ int .Values.ethChainId }}"


### PR DESCRIPTION
- set CFG_LIBP2P_EXTERNAL_IP if serviceType is loadbalancer
- set CFG_LIBP2P_EXTERNAL_IP if serviceType is loadbalancer



| Q                        | A
| ------------------------ | ---
| Service                  | (ghost, musig)
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | `[skip-ci]`
| Any Dependency Changes?  |
| License                  | AGPL

### description of pull request:

- sets CFG_LIBP2P_EXTERNAL_IP if the service type is loadbalancer,
- this makes ghost/musig reachable in the libp2p network which is needed so feeds can achieve peer discovery