### PR TITLE
mainnet ready feed chart

### DIFF
--- a/charts/feed/Chart.lock
+++ b/charts/feed/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.0.8
 - name: ghost
   repository: https://chronicleprotocol.github.io/charts/
-  version: 0.1.6
+  version: 0.1.8
 - name: musig
   repository: https://chronicleprotocol.github.io/charts/
-  version: 0.0.6
-digest: sha256:6326a4c580a1f79125cb25a2e40761af6e2c33a264d044726e9f51fbbd6cfef4
-generated: "2023-09-11T17:52:44.378467265+02:00"
+  version: 0.0.8
+digest: sha256:13da4200feb5d6b0fee622a71490f5bc400391393a10721151f69acf77437da8
+generated: "2023-09-15T13:28:50.175098742+02:00"

--- a/charts/feed/Chart.lock
+++ b/charts/feed/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.0.8
 - name: ghost
   repository: https://chronicleprotocol.github.io/charts/
-  version: 0.1.8
+  version: 0.1.9
 - name: musig
   repository: https://chronicleprotocol.github.io/charts/
-  version: 0.0.8
-digest: sha256:13da4200feb5d6b0fee622a71490f5bc400391393a10721151f69acf77437da8
-generated: "2023-09-15T13:28:50.175098742+02:00"
+  version: 0.0.9
+digest: sha256:fd8fe8f5117b410e5e4b248291e89a0b8bef1080549725862aff15f1a58c69ad
+generated: "2023-09-15T13:57:18.582536045+02:00"

--- a/charts/feed/Chart.yaml
+++ b/charts/feed/Chart.yaml
@@ -34,10 +34,10 @@ dependencies:
     repository: https://chronicleprotocol.github.io/charts/
     condition: tor-proxy.enabled
   - name: ghost
-    version: 0.1.6
+    version: 0.1.8
     repository: https://chronicleprotocol.github.io/charts/
     condition: ghost.enabled
   - name: musig
-    version: 0.0.6
+    version: 0.0.8
     repository: https://chronicleprotocol.github.io/charts/
     condition: musig.enabled

--- a/charts/feed/Chart.yaml
+++ b/charts/feed/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -34,10 +34,10 @@ dependencies:
     repository: https://chronicleprotocol.github.io/charts/
     condition: tor-proxy.enabled
   - name: ghost
-    version: 0.1.8
+    version: 0.1.9
     repository: https://chronicleprotocol.github.io/charts/
     condition: ghost.enabled
   - name: musig
-    version: 0.0.8
+    version: 0.0.9
     repository: https://chronicleprotocol.github.io/charts/
     condition: musig.enabled

--- a/charts/feed/README.md
+++ b/charts/feed/README.md
@@ -1,6 +1,6 @@
 # feed
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Feeds on Kubernetes
 
@@ -15,55 +15,57 @@ A Helm chart for deploying Chronicle Feeds on Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://chronicleprotocol.github.io/charts/ | ghost | 0.1.6 |
-| https://chronicleprotocol.github.io/charts/ | musig | 0.0.6 |
+| https://chronicleprotocol.github.io/charts/ | ghost | 0.1.8 |
+| https://chronicleprotocol.github.io/charts/ | musig | 0.0.8 |
 | https://chronicleprotocol.github.io/charts/ | tor-proxy | 0.0.8 |
 
 ## Values
 
-| Key                                           | Type   | Default                                                                                                        | Description                   |
-|-----------------------------------------------|--------|----------------------------------------------------------------------------------------------------------------|-------------------------------|
-| extraObjects                                  | list   | `[]`                                                                                                           | Extra K8s manifests to deploy |
-| ghost.chainId                                 | string | `nil`                                                                                                          |                               |
-| ghost.enabled                                 | bool   | `true`                                                                                                         |                               |
-| ghost.env.normal.CFG_WEBAPI_ENABLE            | int    | `1`                                                                                                            |                               |
-| ghost.env.normal.CFG_WEBAPI_LISTEN_ADDR       | string | `""`                                                                                                           |                               |
-| ghost.env.normal.CFG_WEBAPI_SOCKS5_PROXY_ADDR | string | `"tor-proxy:9050"`                                                                                             |                               |
-| ghost.ethChainId                              | string | `nil`                                                                                                          |                               |
-| ghost.ethConfig                               | object | `{}`                                                                                                           |                               |
-| ghost.ethRpcUrl                               | string | `nil`                                                                                                          |                               |
-| ghost.fullnameOverride                        | string | `"ghost"`                                                                                                      |                               |
-| ghost.image.tag                               | string | `"0.15.2"`                                                                                                     |                               |
-| ghost.logFormat                               | string | `nil`                                                                                                          |                               |
-| ghost.logLevel                                | string | `nil`                                                                                                          |                               |
-| ghost.rpcUrl                                  | string | `nil`                                                                                                          |                               |
-| ghost.service.ports.libp2p.port               | int    | `8000`                                                                                                         |                               |
-| ghost.service.ports.libp2p.protocol           | string | `"TCP"`                                                                                                        |                               |
-| ghost.service.type                            | string | `"ClusterIP"`                                                                                                  |                               |
-| musig.enabled                                 | bool   | `true`                                                                                                         |                               |
-| musig.env.normal.CFG_WEBAPI_ENABLE            | int    | `1`                                                                                                            |                               |
-| musig.env.normal.CFG_WEBAPI_LISTEN_ADDR       | string | `":8080"`                                                                                                      |                               |
-| musig.env.normal.CFG_WEBAPI_SOCKS5_PROXY_ADDR | string | `"tor-proxy:9050"`                                                                                             |                               |
-| musig.ethChainId                              | int    | `1`                                                                                                            |                               |
-| musig.ethConfig                               | object | `{}`                                                                                                           |                               |
-| musig.ethRpcUrl                               | string | `nil`                                                                                                          |                               |
-| musig.fullnameOverride                        | string | `"musig"`                                                                                                      |                               |
-| musig.image.tag                               | string | `"0.4.1"`                                                                                                      |                               |
-| musig.imagePullSecrets                        | list   | `[]`                                                                                                           |                               |
-| musig.logFormat                               | string | `nil`                                                                                                          |                               |
-| musig.logLevel                                | string | `nil`                                                                                                          |                               |
-| musig.service.ports.libp2p.port               | int    | `8001`                                                                                                         |                               |
-| musig.service.ports.libp2p.protocol           | string | `"TCP"`                                                                                                        |                               |
-| musig.service.ports.webapi.port               | int    | `8080`                                                                                                         |                               |
-| musig.service.ports.webapi.protocol           | string | `"TCP"`                                                                                                        |                               |
-| musig.service.type                            | string | `"ClusterIP"`                                                                                                  |                               |
-| tor-proxy.enabled                             | bool   | `true`                                                                                                         |                               |
-| tor-proxy.env.normal.TOR_EXTRA_ARGS           | string | `"SocksPort 0.0.0.0:9050\nHiddenServiceDir /var/lib/tor/hidden_services\nHiddenServicePort 8888 musig:8080\n"` |                               |
-| tor-proxy.fullnameOverride                    | string | `"tor-proxy"`                                                                                                  |                               |
-| tor-proxy.service.ports.socks.port            | int    | `9050`                                                                                                         |                               |
-| tor-proxy.service.ports.socks.protocol        | string | `"TCP"`                                                                                                        |                               |
-| tor-proxy.service.type                        | string | `"ClusterIP"`                                                                                                  |                               |
-| tor-proxy.torConfig                           | object | `{}`                                                                                                           |                               |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| extraObjects | list | `[]` | Extra K8s manifests to deploy |
+| ghost.chainId | string | `nil` |  |
+| ghost.enabled | bool | `true` |  |
+| ghost.env.normal.CFG_LIBP2P_LISTEN_ADDRS | string | `"/ip4/0.0.0.0/tcp/8000"` |  |
+| ghost.env.normal.CFG_WEBAPI_ENABLE | int | `1` |  |
+| ghost.env.normal.CFG_WEBAPI_LISTEN_ADDR | string | `""` |  |
+| ghost.env.normal.CFG_WEBAPI_SOCKS5_PROXY_ADDR | string | `"tor-proxy:9050"` |  |
+| ghost.ethChainId | string | `nil` |  |
+| ghost.ethConfig | object | `{}` |  |
+| ghost.ethRpcUrl | string | `nil` |  |
+| ghost.fullnameOverride | string | `"ghost"` |  |
+| ghost.image.tag | string | `"0.17.0"` |  |
+| ghost.logFormat | string | `nil` |  |
+| ghost.logLevel | string | `"warning"` |  |
+| ghost.rpcUrl | string | `nil` |  |
+| ghost.service.ports.libp2p.port | int | `8000` |  |
+| ghost.service.ports.libp2p.protocol | string | `"TCP"` |  |
+| ghost.service.type | string | `"LoadBalancer"` |  |
+| musig.enabled | bool | `true` |  |
+| musig.env.normal.CFG_LIBP2P_LISTEN_ADDRS | string | `"/ip4/0.0.0.0/tcp/8001"` |  |
+| musig.env.normal.CFG_WEBAPI_ENABLE | int | `1` |  |
+| musig.env.normal.CFG_WEBAPI_LISTEN_ADDR | string | `":8080"` |  |
+| musig.env.normal.CFG_WEBAPI_SOCKS5_PROXY_ADDR | string | `"tor-proxy:9050"` |  |
+| musig.ethChainId | int | `1` |  |
+| musig.ethConfig | object | `{}` |  |
+| musig.ethRpcUrl | string | `nil` |  |
+| musig.fullnameOverride | string | `"musig"` |  |
+| musig.image.tag | string | `"0.7.1"` |  |
+| musig.imagePullSecrets | list | `[]` |  |
+| musig.logFormat | string | `nil` |  |
+| musig.logLevel | string | `"warning"` |  |
+| musig.service.ports.libp2p.port | int | `8001` |  |
+| musig.service.ports.libp2p.protocol | string | `"TCP"` |  |
+| musig.service.ports.webapi.port | int | `8080` |  |
+| musig.service.ports.webapi.protocol | string | `"TCP"` |  |
+| musig.service.type | string | `"LoadBalancer"` |  |
+| tor-proxy.enabled | bool | `true` |  |
+| tor-proxy.env.normal.TOR_EXTRA_ARGS | string | `"SocksPort 0.0.0.0:9050\nHiddenServiceDir /var/lib/tor/hidden_services\nHiddenServicePort 8888 musig:8080\n"` |  |
+| tor-proxy.fullnameOverride | string | `"tor-proxy"` |  |
+| tor-proxy.service.ports.socks.port | int | `9050` |  |
+| tor-proxy.service.ports.socks.protocol | string | `"TCP"` |  |
+| tor-proxy.service.type | string | `"ClusterIP"` |  |
+| tor-proxy.torConfig | object | `{}` |  |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/feed/README.md
+++ b/charts/feed/README.md
@@ -1,6 +1,6 @@
 # feed
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Feeds on Kubernetes
 
@@ -15,8 +15,8 @@ A Helm chart for deploying Chronicle Feeds on Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://chronicleprotocol.github.io/charts/ | ghost | 0.1.8 |
-| https://chronicleprotocol.github.io/charts/ | musig | 0.0.8 |
+| https://chronicleprotocol.github.io/charts/ | ghost | 0.1.9 |
+| https://chronicleprotocol.github.io/charts/ | musig | 0.0.9 |
 | https://chronicleprotocol.github.io/charts/ | tor-proxy | 0.0.8 |
 
 ## Values
@@ -26,7 +26,6 @@ A Helm chart for deploying Chronicle Feeds on Kubernetes
 | extraObjects | list | `[]` | Extra K8s manifests to deploy |
 | ghost.chainId | string | `nil` |  |
 | ghost.enabled | bool | `true` |  |
-| ghost.env.normal.CFG_LIBP2P_LISTEN_ADDRS | string | `"/ip4/0.0.0.0/tcp/8000"` |  |
 | ghost.env.normal.CFG_WEBAPI_ENABLE | int | `1` |  |
 | ghost.env.normal.CFG_WEBAPI_LISTEN_ADDR | string | `""` |  |
 | ghost.env.normal.CFG_WEBAPI_SOCKS5_PROXY_ADDR | string | `"tor-proxy:9050"` |  |
@@ -42,7 +41,6 @@ A Helm chart for deploying Chronicle Feeds on Kubernetes
 | ghost.service.ports.libp2p.protocol | string | `"TCP"` |  |
 | ghost.service.type | string | `"LoadBalancer"` |  |
 | musig.enabled | bool | `true` |  |
-| musig.env.normal.CFG_LIBP2P_LISTEN_ADDRS | string | `"/ip4/0.0.0.0/tcp/8001"` |  |
 | musig.env.normal.CFG_WEBAPI_ENABLE | int | `1` |  |
 | musig.env.normal.CFG_WEBAPI_LISTEN_ADDR | string | `":8080"` |  |
 | musig.env.normal.CFG_WEBAPI_SOCKS5_PROXY_ADDR | string | `"tor-proxy:9050"` |  |

--- a/charts/feed/values.yaml
+++ b/charts/feed/values.yaml
@@ -2,7 +2,7 @@ ghost:
   # values for ghost: https://github.com/chronicleprotocol/charts/blob/main/charts/ghost/values.yaml
   enabled: true
   image:
-    tag: "0.16.0"
+    tag: "0.17.0"
   fullnameOverride: "ghost"
   ethConfig: {}
     # ethFrom:
@@ -16,7 +16,7 @@ ghost:
     #   key: "ethPass"
 
   service:
-    type: ClusterIP
+    type: LoadBalancer
     ports:
       libp2p:
         port: 8000
@@ -39,7 +39,7 @@ ghost:
 
       # CFG_ENVIRONMENT: "prod"
       # CFG_FEEDS: "prod"
-
+      CFG_LIBP2P_LISTEN_ADDRS: "/ip4/0.0.0.0/tcp/8000"
       CFG_WEBAPI_ENABLE: 1
       CFG_WEBAPI_LISTEN_ADDR: ""
       CFG_WEBAPI_SOCKS5_PROXY_ADDR: "tor-proxy:9050"
@@ -49,10 +49,10 @@ musig:
   enabled: true
   fullnameOverride: "musig"
   image:
-    tag: "0.5.1"
+    tag: "0.7.1"
   imagePullSecrets: []
   service:
-    type: ClusterIP
+    type: LoadBalancer
     ports:
       libp2p:
         port: 8001
@@ -86,7 +86,7 @@ musig:
 
       # CFG_ENVIRONMENT: "prod"
       # CFG_FEEDS: "prod"
-
+      CFG_LIBP2P_LISTEN_ADDRS: "/ip4/0.0.0.0/tcp/8001"
       CFG_WEBAPI_ENABLE: 1
       CFG_WEBAPI_LISTEN_ADDR: ":8080"
       CFG_WEBAPI_SOCKS5_PROXY_ADDR: "tor-proxy:9050"

--- a/charts/feed/values.yaml
+++ b/charts/feed/values.yaml
@@ -39,7 +39,7 @@ ghost:
 
       # CFG_ENVIRONMENT: "prod"
       # CFG_FEEDS: "prod"
-      CFG_LIBP2P_LISTEN_ADDRS: "/ip4/0.0.0.0/tcp/8000"
+
       CFG_WEBAPI_ENABLE: 1
       CFG_WEBAPI_LISTEN_ADDR: ""
       CFG_WEBAPI_SOCKS5_PROXY_ADDR: "tor-proxy:9050"
@@ -86,7 +86,7 @@ musig:
 
       # CFG_ENVIRONMENT: "prod"
       # CFG_FEEDS: "prod"
-      CFG_LIBP2P_LISTEN_ADDRS: "/ip4/0.0.0.0/tcp/8001"
+
       CFG_WEBAPI_ENABLE: 1
       CFG_WEBAPI_LISTEN_ADDR: ":8080"
       CFG_WEBAPI_SOCKS5_PROXY_ADDR: "tor-proxy:9050"


### PR DESCRIPTION
- prep charts
- bump subcharts for ghost and musig
- subcharts include changes to make ghost and musig discoverable


| Q                        | A
| ------------------------ | ---
| Service                  | feed with ghost and musig
| Fixed Issues?            | no
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | `[skip-ci]`
| Any Dependency Changes?  |
| License                  | AGPL

### description of pull request:

-
