### PR TITLE
fix: change base geth entrypoint

### DIFF
--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/base/templates/statefulset.yaml
+++ b/charts/base/templates/statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           resources:
             {{- toYaml .Values.geth.resources | nindent 12 }}
-          command: ["bash", "./geth-entrypoint"]
+          command: ["bash", "./execution-entrypoint"]
           args:
           {{- if .Values.geth.args }}
             {{- toYaml .Values.geth.args | nindent 12 }}


### PR DESCRIPTION
`geth-entrypoint` binary is not available anymore