### PR TITLE
Update default metrics path for prometheus in geth

### DIFF
--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/base/README.md
+++ b/charts/base/README.md
@@ -1,6 +1,6 @@
 # base
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.0](https://img.shields.io/badge/AppVersion-v0.9.0-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.0](https://img.shields.io/badge/AppVersion-v0.9.0-informational?style=flat-square)
 
 A Helm chart for deploying Base RPC nodes on Kubernetes
 
@@ -93,7 +93,7 @@ A Helm chart for deploying Base RPC nodes on Kubernetes
 | serviceMonitor.interval | string | `"1m"` | ServiceMonitor scrape interval |
 | serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
 | serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor |
-| serviceMonitor.path | string | `"/debug/metrics"` | Path to scrape |
+| serviceMonitor.path | string | `"/debug/metrics/prometheus"` | Path to scrape |
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabelings |
 | serviceMonitor.scheme | string | `"http"` | ServiceMonitor scheme |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | ServiceMonitor scrape timeout |

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -192,7 +192,7 @@ serviceMonitor:
   # https://github.com/coreos/prometheus-operator
   enabled: false
   # -- Path to scrape
-  path: /debug/metrics
+  path: /debug/metrics/prometheus
   # -- Alternative namespace for ServiceMonitor
   namespace: null
   # -- Additional ServiceMonitor labels


### PR DESCRIPTION
The default URL path is not compatible with Prometheus. Since the endpoint returns JSON output, enabling it alone will not make it functional with Prometheus. The default path for Geth is different. For more information, refer to the [Prometheus-formatted metrics data documentation](https://geth.ethereum.org/docs/monitoring/metrics).


<img width="822" alt="Screenshot 2024-07-21 at 15 17 10" src="https://github.com/user-attachments/assets/c1396749-18e8-40f8-9b13-7739244d737d">
