### PR TITLE
[erpc]: bump erpc image

### DIFF
--- a/charts/erpc/Chart.yaml
+++ b/charts/erpc/Chart.yaml
@@ -21,13 +21,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.0.44
+appVersion: 0.0.45
 
 dependencies:
 - name: redis

--- a/charts/erpc/README.md
+++ b/charts/erpc/README.md
@@ -1,6 +1,6 @@
 # erpc
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.44](https://img.shields.io/badge/AppVersion-0.0.44-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.45](https://img.shields.io/badge/AppVersion-0.0.45-informational?style=flat-square)
 
 A Helm chart for deploying eRPC — fault-tolerant evm rpc proxy with reorg-aware permanent caching to Kubernetes
 


### PR DESCRIPTION
- upgrades to erpc to [0.0.45](https://github.com/erpc/erpc/releases/tag/0.0.45) 
