### PR TITLE
feat(validator): support global.topologySpreadConstraints

### DIFF
--- a/charts/validator/Chart.yaml
+++ b/charts/validator/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.6.0"
+version: "0.6.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/validator/README.md
+++ b/charts/validator/README.md
@@ -28,7 +28,7 @@ A Helm chart for deploying Chronicle Validator on Kubernetes
 | ghost.service.ports.libp2p | object | `{"port":8000,"protocol":"TCP"}` | libp2p port for the validator service |
 | ghost.service.type | string | `"LoadBalancer"` | Type of service for the validator, only `LoadBalancer` supported for now |
 | ghost.watchdogConfigReg | string | `"0x94Fea534aef6df5cF66C2DAE5CE0A05d10C068F3"` | WATCHDOG onchain config address |
-| global | object | `{"affinity":{},"chainId":1,"chainName":"eth","chainTxType":"eip1559","fullnameOverride":"ghost","image":{"pullPolicy":"Always","repository":"ghcr.io/chronicleprotocol/ghost","tag":""},"imagePullSecrets":[],"liveness":{"enabled":true,"livenessProbe":{"httpGet":{"path":"/healthz","port":9100},"initialDelaySeconds":30,"periodSeconds":60}},"logFormat":"text","logLevel":"info","metrics":{"enabled":true,"port":9090},"nameOverride":"","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"readiness":{"enabled":true,"readinessProbe":{"httpGet":{"path":"/healthz","port":9100},"initialDelaySeconds":30,"periodSeconds":60}},"replicaCount":1,"resources":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"tolerations":[]}` | Global values for the validator chart, values are used across the chart resources |
+| global | object | `{"affinity":{},"chainId":1,"chainName":"eth","chainTxType":"eip1559","fullnameOverride":"ghost","image":{"pullPolicy":"Always","repository":"ghcr.io/chronicleprotocol/ghost","tag":""},"imagePullSecrets":[],"liveness":{"enabled":true,"livenessProbe":{"httpGet":{"path":"/healthz","port":9100},"initialDelaySeconds":30,"periodSeconds":60}},"logFormat":"text","logLevel":"info","metrics":{"enabled":true,"port":9090},"nameOverride":"","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"readiness":{"enabled":true,"readinessProbe":{"httpGet":{"path":"/healthz","port":9100},"initialDelaySeconds":30,"periodSeconds":60}},"replicaCount":1,"resources":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"tolerations":[],"topologySpreadConstraints":[]}` | Global values for the validator chart, values are used across the chart resources |
 | global.affinity | object | `{}` | pod Affinity spec applied validator |
 | global.chainId | int | `1` | chain id for the "target" or "main" chain we use for the validator. Can be mainnet ethereum `1` or sepolia ethereum `11155111` |
 | global.chainName | string | `"eth"` | chain name for the "target" or "main" chain we use for the validator |
@@ -50,6 +50,7 @@ A Helm chart for deploying Chronicle Validator on Kubernetes
 | global.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | global.serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
 | global.tolerations | list | `[]` | Tolerations applied validator |
+| global.topologySpreadConstraints | list | `[]` | Topology spread constraints applied to both ghost and vao pods |
 | serviceMonitor.annotations | object | `{}` | Additional ServiceMonitor annotations |
 | serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator https://github.com/coreos/prometheus-operator |
 | serviceMonitor.interval | string | `"60s"` | ServiceMonitor scrape interval |

--- a/charts/validator/templates/deployment-vao.yaml
+++ b/charts/validator/templates/deployment-vao.yaml
@@ -185,3 +185,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+
+      {{- with .Values.global.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/validator/templates/deployment.yaml
+++ b/charts/validator/templates/deployment.yaml
@@ -175,3 +175,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+
+      {{- with .Values.global.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/validator/values.yaml
+++ b/charts/validator/values.yaml
@@ -112,6 +112,15 @@ global:
   # -- pod Affinity spec applied validator
   affinity: {}
 
+  # -- Topology spread constraints applied to both ghost and vao pods
+  topologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: kubernetes.io/hostname
+    #   whenUnsatisfiable: ScheduleAnyway
+    #   labelSelector:
+    #     matchLabels:
+    #       app.kubernetes.io/name: ghost
+
 # -- Values for Ghost
 ghost:
   # -- Image tag for the validator (overrides global image if set)


### PR DESCRIPTION
## Summary
Expose \`global.topologySpreadConstraints\` on the validator chart, rendered on **both** the ghost and the vao Deployments. One setting covers both halves, matching how \`global.nodeSelector\`, \`global.affinity\`, and \`global.tolerations\` already work.

## Why
Consumers (\`chronicleprotocol/app-of-apps\`) deploy multi-replica ghost/vao validators plus per-feed validators that share the Chronicle Environment pool. Preferred anti-affinity only handles pairwise repulsion; topology spread constraints are the k8s-native primitive for balanced placement across nodes/zones.

## Scope
- \`charts/validator/templates/deployment.yaml\` (ghost): 3-line \`{{- with .Values.global.topologySpreadConstraints }}\` block after tolerations.
- \`charts/validator/templates/deployment-vao.yaml\` (vao): same block.
- \`charts/validator/values.yaml\`: \`global.topologySpreadConstraints: []\` default with commented example.
- \`charts/validator/Chart.yaml\`: version \`0.6.0 -> 0.6.1\` so chart-releaser publishes.
- \`charts/validator/README.md\`: regenerated via \`helm-docs\`.

## Verification
- \`helm-docs\` run locally.
- \`helm template\` with a topology spread set renders the block on both deployments (verified by counting occurrences in the template output: 2, matching the two Deployments).
- Default (empty list) leaves both pod specs unchanged.

## Test plan
- [ ] \`ct lint --config ct.yaml\` passes.
- [ ] \`ct install\` on kind cluster renders cleanly with the empty-list default.
- [ ] Consumer repo (\`app-of-apps\`) will bump \`targetRevision\` in a follow-up PR to pick this up for prod-chronicle-feed, stage-vao-validator1, staging-feed2/3/4, and the test-defi-validator.