### PR TITLE
fix(spectre): add watch verb to spectre-test Role for kubectl logs -f [sc-17583]

### DIFF
--- a/charts/spectre/Chart.yaml
+++ b/charts/spectre/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/spectre/templates/role.yaml
+++ b/charts/spectre/templates/role.yaml
@@ -5,4 +5,4 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Summary

Add `watch` verb to the `spectre-test` Role. One-line change plus chart version bump (0.3.5 → 0.3.6).

## Why

ArgoCD Sync hooks in [app-of-apps](https://github.com/chronicleprotocol/app-of-apps/blob/main/prod/prod-relay-appset.yaml) use

```bash
kubectl logs --tail=0 -f \$POD_NAME | grep -m 1 "tag=DATA_POINT_STORE"
```

to gate progressive rollouts. The follow-mode stream (`-f`) needs `watch` verb on `pods`/`pods/log` for RBAC-strict clusters / newer kubectl. The bundled `spectre-test` Role was `["get", "list"]` only.

The app-of-apps layer currently works around this by duplicating a custom `check-logs` SA + Role + RoleBinding (with `watch`) inside `extraObjects` — that's dead-code bloat. Once this lands, app-of-apps can delete all that and use the chart-provided SA directly. Context: [Discord thread with @WesleyCharlesBlake 2026-04-21](https://discord.com/channels/...).

## Diff

```diff
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]
```

+ `version: 0.3.5` → `0.3.6` in `Chart.yaml`.

## Not in scope

- `validator` chart already has `watch` on its own Role (`charts/validator/templates/role.yaml:8,11`). No change needed.
- app-of-apps cleanup of legacy `check-logs` extraObjects — follow-up PR, depends on this version being published.

## Test plan

- [x] `ct lint` passes
- [x] `ct install` passes in kind cluster
- [ ] After merge, chart-releaser publishes `spectre-0.3.6` to GHCR + chronicleprotocol.github.io/charts
- [ ] Follow-up app-of-apps PR can then reference the new chart version via the existing `targetRevision: '*.*.*'`

Refs:
- sc-17583
- app-of-apps PR #1239 (closing — superseded by this approach per @WesleyCharlesBlake's review)