### PR TITLE
feat(validator): Adds helios lightclient for eth

### DIFF
--- a/charts/validator/templates/deployment-vao.yaml
+++ b/charts/validator/templates/deployment-vao.yaml
@@ -99,7 +99,11 @@ spec:
             - name: CFG_CHAIN_ID
               value: {{ .Values.global.chainId | default "1" | quote }}
             - name: CFG_CHAIN_RPC_URLS
+            {{- if .Values.helios.enabled }}
+              value: "http://localhost:{{ .Values.helios.port }}"
+            {{- else }}
               value: {{ .Values.ghost.rpcUrl | quote }}
+            {{- end }}
               {{- if .Values.global.chainTxType }}
             - name: CFG_CHAIN_TX_TYPE
               value: {{ .Values.global.chainTxType | default "eip1559" | quote }}
@@ -144,7 +148,6 @@ spec:
           resources:
             {{- toYaml ( .Values.vao.resources | default .Values.global.resources ) | nindent 12 }}
 
-
           {{- if .Values.vao.extraVolumes }}
           volumeMounts:
             {{- range .Values.vao.extraVolumes }}
@@ -156,6 +159,27 @@ spec:
               readOnly: {{ .readOnly | default true }}
             {{- end }}
           {{- end }}
+
+      {{- if .Values.helios.enabled }}
+        - name: helios
+          image: "{{ .Values.helios.image.repository }}:{{ .Values.helios.image.tag }}"
+          imagePullPolicy: {{ .Values.helios.image.pullPolicy }}
+          args:
+            - "node"
+            - "--chain=ethereum"
+            - "--execution-rpc={{ .Values.ghost.rpcUrl }}"
+            - "--consensus-rpc={{ .Values.helios.consensusRpc }}"
+            - "--rpc-bind-ip=0.0.0.0"
+            - "--rpc-port={{ .Values.helios.port }}"
+          ports:
+            - name: helios-rpc
+              containerPort: {{ .Values.helios.port }}
+              protocol: TCP
+          {{- with .Values.helios.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
 
       {{- if .Values.vao.extraVolumes }}
       volumes:

--- a/charts/validator/templates/deployment.yaml
+++ b/charts/validator/templates/deployment.yaml
@@ -101,7 +101,11 @@ spec:
             - name: CFG_CHAIN_ID
               value: {{ .Values.global.chainId | default "1" | quote }}
             - name: CFG_CHAIN_RPC_URLS
+            {{- if .Values.helios.enabled }}
+              value: "http://localhost:{{ .Values.helios.port }}"
+            {{- else }}
               value: {{ .Values.ghost.rpcUrl | quote }}
+            {{- end }}
               {{- if .Values.global.chainTxType }}
             - name: CFG_CHAIN_TX_TYPE
               value: {{ .Values.global.chainTxType | default "eip1559" | quote }}
@@ -160,6 +164,26 @@ spec:
           resources:
             {{- toYaml ( .Values.ghost.resources | default .Values.global.resources ) | nindent 12 }}
 
+      {{- if .Values.helios.enabled }}
+        - name: helios
+          image: "{{ .Values.helios.image.repository }}:{{ .Values.helios.image.tag }}"
+          imagePullPolicy: {{ .Values.helios.image.pullPolicy }}
+          args:
+            - "node"
+            - "--chain=ethereum"
+            - "--execution-rpc={{ .Values.ghost.rpcUrl }}"
+            - "--consensus-rpc={{ .Values.helios.consensusRpc }}"
+            - "--rpc-bind-ip=0.0.0.0"
+            - "--rpc-port={{ .Values.helios.port }}"
+          ports:
+            - name: helios-rpc
+              containerPort: {{ .Values.helios.port }}
+              protocol: TCP
+          {{- with .Values.helios.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
 
       {{- with .Values.global.nodeSelector }}
       nodeSelector:

--- a/charts/validator/values.yaml
+++ b/charts/validator/values.yaml
@@ -269,6 +269,27 @@ vao:
     #   subPath: keyfile.json  # Mount specific file from secret
     #   readOnly: true
 
+# -- Helios light client sidecar for trustless Ethereum RPC
+helios:
+  # -- Enable Helios light client sidecar in both ghost and vao pods
+  enabled: false
+  image:
+    repository: ghcr.io/a16z/helios
+    tag: "latest"
+    pullPolicy: Always
+  # -- Consensus layer (beacon API) RPC used by Helios to verify blocks
+  consensusRpc: ""
+  # -- Local RPC port exposed by Helios (ghost/vao connect to this via localhost)
+  port: 8547
+  # -- Resources constraints for the Helios sidecar
+  resources: {}
+    # limits:
+    #   cpu: 200m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
 # -- Values for Tor Proxy (subchart of ghost)
 tor-proxy:
   # -- values for tor-proxy, installs [tor-controller](/crds/tor-controller.yaml) and creates an [onionService CRD](/templates/tor-onion-service.yaml)


### PR DESCRIPTION
To move the discussion forward, only enabled for eth for now - highest impact chain. Consensus node is a new dependency to configs.