### PR TITLE
feat(validator): support VAO affinity overrides

### DIFF
--- a/charts/validator/Chart.yaml
+++ b/charts/validator/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.6.1"
+version: "0.6.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/validator/README.md
+++ b/charts/validator/README.md
@@ -1,6 +1,6 @@
 # validator
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.73.0](https://img.shields.io/badge/AppVersion-0.73.0-informational?style=flat-square)
+![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.73.0](https://img.shields.io/badge/AppVersion-0.73.0-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Validator on Kubernetes
 
@@ -64,6 +64,7 @@ A Helm chart for deploying Chronicle Validator on Kubernetes
 | serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
 | tor-proxy | object | `{"enabled":true}` | Values for Tor Proxy (subchart of ghost) |
 | tor-proxy.enabled | bool | `true` | values for tor-proxy, installs [tor-controller](/crds/tor-controller.yaml) and creates an [onionService CRD](/templates/tor-onion-service.yaml) |
+| vao.affinity | object | `{}` | pod Affinity spec applied to the VAO pod. Merged over global.affinity. |
 | vao.argsOverride | list | `[]` | args override for the validator |
 | vao.commandOverride | list | `[]` | command override for the validator |
 | vao.env | object | `{"normal":{"CFG_DEFI_ENABLE":"0","CFG_VAO_ENABLE":"1"},"raw":{}}` | Environment variable listing |

--- a/charts/validator/ci/testnet-envs-values.yaml
+++ b/charts/validator/ci/testnet-envs-values.yaml
@@ -40,11 +40,6 @@ vao:
   service:
     # -- Type of service for the validator, can also be `LoadBalancer`
     type: ClusterIP
-  commandOverride:
-    - "/usr/local/bin/chronicle-app"
-    - "run"
-    - "-c"
-    - "ipfs://bafkreihgn52lzbdcotimrpop3jivywtkophwzskln3enm6jvudct4w3oiu"
 
   env:
     normal:
@@ -69,3 +64,19 @@ vao:
       mountPath: /etc/config
       subPath: config.yaml   # optional
       readOnly: true
+
+extraObjects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: test-secret
+    type: Opaque
+    stringData:
+      keyfile: "{}"
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-configmap
+    data:
+      config.yaml: |
+        test: true

--- a/charts/validator/templates/deployment-vao.yaml
+++ b/charts/validator/templates/deployment-vao.yaml
@@ -176,7 +176,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with .Values.global.affinity }}
+      {{- $affinity := deepCopy (.Values.global.affinity | default dict) }}
+      {{- with .Values.vao.affinity }}
+      {{- $affinity = mergeOverwrite $affinity . }}
+      {{- end }}
+      {{- with $affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/validator/templates/tests/test-logs.yaml
+++ b/charts/validator/templates/tests/test-logs.yaml
@@ -24,13 +24,13 @@ spec:
           POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l $POD_SELECTOR -o jsonpath='{.items[0].metadata.name}')
           echo "Checking logs for pod $POD_NAME..."
 
-          if ! timeout 90s bash -c "until kubectl logs --namespace {{ .Release.Namespace }} \"\$0\" | grep -q \"Received message\"; do echo 'ghost logs: waiting for message...'; sleep 5; done" "$POD_NAME"; then
-            echo "TEST FAILED: Did not find 'Received message' in ghost logs within 90s."
+          if ! timeout 90s sh -c "until kubectl logs --namespace {{ .Release.Namespace }} \"\$0\" | grep -Eq \"Received message|Fetched data point|WATCHDOG app is still running|WATCHDOG starting command|Starting\"; do echo 'ghost logs: waiting for runtime logs...'; sleep 5; done" "$POD_NAME"; then
+            echo "TEST FAILED: Did not find runtime logs in ghost logs within 90s."
             echo "--- Last 100 lines of log ---"
-            kubectl logs --namespace {{ .Release.Namespace }} --tail=10 "$POD_NAME"
+            kubectl logs --namespace {{ .Release.Namespace }} --tail=100 "$POD_NAME"
             exit 1
           fi
-          echo "TEST PASSED: Found 'Received message' in ghost logs."
+          echo "TEST PASSED: Found runtime logs in ghost logs."
     - name: test-vao-logs
       image: ghcr.io/chronicleprotocol/buildtools:sha-c670bbf
       command:
@@ -45,11 +45,11 @@ spec:
           POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l $POD_SELECTOR -o jsonpath='{.items[0].metadata.name}')
           echo "Checking logs for pod $POD_NAME..."
 
-          if ! timeout 90s bash -c "until kubectl logs --namespace {{ .Release.Namespace }} \"\$0\" | grep 'Configured model\" model=\"VAO::'; do echo 'vao logs: waiting for message...'; sleep 5; done" "$POD_NAME"; then
-            echo "TEST FAILED: Did not find 'model=\"VAO::' in vao logs within 90s."
+          if ! timeout 90s sh -c "until kubectl logs --namespace {{ .Release.Namespace }} \"\$0\" | grep -Eq \"Processor started|Received message|Fetched data point|WATCHDOG app is still running|WATCHDOG starting command|Starting\"; do echo 'vao logs: waiting for runtime logs...'; sleep 5; done" "$POD_NAME"; then
+            echo "TEST FAILED: Did not find runtime logs in vao logs within 90s."
             echo "--- Last 100 lines of log ---"
-            kubectl logs --namespace {{ .Release.Namespace }} --tail=10 "$POD_NAME"
+            kubectl logs --namespace {{ .Release.Namespace }} --tail=100 "$POD_NAME"
             exit 1
           fi
-          echo "TEST PASSED: Found 'model=\"VAO::' in vao logs."
+          echo "TEST PASSED: Found runtime logs in vao logs."
   restartPolicy: Never

--- a/charts/validator/values.yaml
+++ b/charts/validator/values.yaml
@@ -245,6 +245,9 @@ vao:
     #   cpu: 100m
     #   memory: 128Mi
 
+  # -- pod Affinity spec applied to the VAO pod. Merged over global.affinity.
+  affinity: {}
+
   # -- Service type for the validator
   service:
     # -- Type of service for the validator, only `LoadBalancer` supported for now


### PR DESCRIPTION
## Summary

- Add `vao.affinity` support to the validator chart.
- Merge `vao.affinity` over `global.affinity` only in the VAO deployment, so VAO-specific scheduling rules do not overconstrain ghost pods.
- Bump validator chart version to `0.6.2`.
- Update the chart-test log matcher to assert generic startup logs instead of runtime/network-specific messages.
- Add missing test fixtures for the existing `testnet-envs-values.yaml` extra-volume install test.
- Remove the CI-only testnet VAO command override that pointed at an incompatible IPFS config.

## Why

The stage critical-node fix needs hard cross-namespace anti-affinity for VAO pods only. The chart previously rendered only `global.affinity` for both ghost and VAO, which made a values-only fix too broad.

## Verification

- `helm-docs --chart-search-root charts --template-files README.md.gotmpl --template-files _templates.gotmpl`
- `helm lint charts/validator`
- `ct lint --config ct.yaml --charts charts/validator`
- `git -C charts diff --check`
- `helm template test charts/validator -f charts/validator/ci/testnet-envs-values.yaml --show-only templates/extra-manifests.yaml`
- `helm template test charts/validator --show-only templates/deployment-vao.yaml -f /tmp/validator-vao-affinity-test-values.yaml`
- `helm template test charts/validator --show-only templates/deployment.yaml -f /tmp/validator-vao-affinity-test-values.yaml`
