### PR TITLE
ci: pin external GitHub Actions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,22 +8,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
         with:
           version: v3.11.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.14'
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -37,7 +37,7 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.14.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
           git config user.name "Chronicle_Protocol_CI"
           git config user.email "helm-maintainers@users.noreply.github.com"
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
         with:
           version: v3.8.1
 
@@ -50,7 +50,7 @@ jobs:
             helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
           done
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f
         with:
           charts_dir: charts
           config: cr.yaml


### PR DESCRIPTION
Pins third-party GitHub Actions `uses:` references to full commit SHAs.

Context: RFC-043 GitHub organization security hardening.

This PR does not change GitHub org settings, branch protection, or workflow permissions.

Pinned references:
- `.github/workflows/lint-test.yaml:11` `actions/checkout@v6` -> `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd`
- `.github/workflows/lint-test.yaml:16` `azure/setup-helm@v4` -> `azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4`
- `.github/workflows/lint-test.yaml:20` `actions/setup-python@v6` -> `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405`
- `.github/workflows/lint-test.yaml:26` `helm/chart-testing-action@v2.8.0` -> `helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f`
- `.github/workflows/lint-test.yaml:40` `helm/kind-action@v1.14.0` -> `helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc`
- `.github/workflows/release.yaml:17` `actions/checkout@v6` -> `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd`
- `.github/workflows/release.yaml:26` `azure/setup-helm@v4` -> `azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4`
- `.github/workflows/release.yaml:53` `helm/chart-releaser-action@v1.7.0` -> `helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f`