### PR TITLE
feat: support topology-aware Service controls [sc-18128]

### DIFF
--- a/charts/erpc/Chart.yaml
+++ b/charts/erpc/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.4
+version: 0.6.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/erpc/README.md
+++ b/charts/erpc/README.md
@@ -1,6 +1,6 @@
 # erpc
 
-![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.64](https://img.shields.io/badge/AppVersion-0.0.64-informational?style=flat-square)
+![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.64](https://img.shields.io/badge/AppVersion-0.0.64-informational?style=flat-square)
 
 A Helm chart for deploying eRPC — fault-tolerant evm rpc proxy with reorg-aware permanent caching to Kubernetes
 
@@ -49,6 +49,7 @@ A Helm chart for deploying eRPC — fault-tolerant evm rpc proxy with reorg-awar
 | service.ports.http.protocol | string | `"TCP"` |  |
 | service.ports.metrics.port | int | `4001` |  |
 | service.ports.metrics.protocol | string | `"TCP"` |  |
+| service.trafficDistribution | string | `""` | Optional Kubernetes Service traffic distribution hint, for example PreferSameZone. |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/erpc/templates/service.yaml
+++ b/charts/erpc/templates/service.yaml
@@ -13,6 +13,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.trafficDistribution }}
+  trafficDistribution: {{ . | quote }}
+  {{- end }}
   ports:
     {{- range $key, $val := .Values.service.ports }}
     - port: {{ $val.port }}

--- a/charts/erpc/values.yaml
+++ b/charts/erpc/values.yaml
@@ -60,6 +60,8 @@ securityContext: {}
 
 service:
   type: ClusterIP
+  # -- Optional Kubernetes Service traffic distribution hint, for example PreferSameZone.
+  trafficDistribution: ""
   annotations: {}
   labels: {}
   ports:

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.68.3](https://img.shields.io/badge/AppVersion-0.68.3-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.68.3](https://img.shields.io/badge/AppVersion-0.68.3-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle spire to  Kubernetes
 
@@ -47,6 +47,7 @@ A Helm chart for deploying Chronicle spire to  Kubernetes
 | liveness | object | `{"enabled":true,"livenessProbe":{"initialDelaySeconds":10,"periodSeconds":10,"tcpSocket":{"port":"libp2p"}}}` | Liveness probe |
 | logFormat | string | `nil` |  |
 | logLevel | string | `nil` |  |
+| metricsService | object | `{"annotations":{},"enabled":false,"port":9090,"protocol":"TCP","targetPort":9090}` | Optional ClusterIP metrics service for scraping metrics without exposing the metrics port on a public LoadBalancer. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
@@ -56,8 +57,11 @@ A Helm chart for deploying Chronicle spire to  Kubernetes
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |
+| service.externalTrafficPolicy | string | `""` | Optional LoadBalancer traffic policy, for example Local. |
+| service.loadBalancerClass | string | `""` | Optional LoadBalancer class, for example service.k8s.aws/nlb. |
 | service.ports.libp2p.port | int | `8000` |  |
 | service.ports.libp2p.protocol | string | `"TCP"` |  |
+| service.trafficDistribution | string | `""` | Optional Kubernetes Service traffic distribution hint, for example PreferSameZone. |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/spire/templates/service-metrics.yaml
+++ b/charts/spire/templates/service-metrics.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.metricsService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spire.fullname" . }}-metrics
+  annotations:
+  {{- with .Values.metricsService.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "spire.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+spec:
+  type: ClusterIP
+  ports:
+    - name: {{ .Values.serviceMonitor.port }}
+      port: {{ .Values.metricsService.port }}
+      targetPort: {{ .Values.metricsService.targetPort }}
+      protocol: {{ .Values.metricsService.protocol }}
+  selector:
+    {{- include "spire.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/spire/templates/service.yaml
+++ b/charts/spire/templates/service.yaml
@@ -10,6 +10,15 @@ metadata:
     {{- include "spire.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.service.trafficDistribution }}
+  trafficDistribution: {{ . | quote }}
+  {{- end }}
   ports:
     {{- range $key, $val := .Values.service.ports }}
     - port: {{ $val.port }}

--- a/charts/spire/templates/servicemonitor.yaml
+++ b/charts/spire/templates/servicemonitor.yaml
@@ -36,7 +36,10 @@ spec:
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:
-      {{- include "spire.selectorLabels" . | nindent 8 }}
+{{ include "spire.selectorLabels" . | nindent 6 }}
+      {{- if .Values.metricsService.enabled }}
+      app.kubernetes.io/component: metrics
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -44,6 +44,12 @@ securityContext:
 
 service:
   type: ClusterIP
+  # -- Optional LoadBalancer class, for example service.k8s.aws/nlb.
+  loadBalancerClass: ""
+  # -- Optional LoadBalancer traffic policy, for example Local.
+  externalTrafficPolicy: ""
+  # -- Optional Kubernetes Service traffic distribution hint, for example PreferSameZone.
+  trafficDistribution: ""
   ports:
     libp2p:
       port: 8000
@@ -58,6 +64,14 @@ service:
   annotations:
     {}
     # external-dns.alpha.kubernetes.io/hostname: DOMAIN_NAME
+
+# -- Optional ClusterIP metrics service for scraping metrics without exposing the metrics port on a public LoadBalancer.
+metricsService:
+  enabled: false
+  annotations: {}
+  port: 9090
+  targetPort: 9090
+  protocol: TCP
 
 # -- Liveness probe
 liveness:

--- a/charts/validator/Chart.yaml
+++ b/charts/validator/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.6.3"
+version: "0.6.4"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/validator/README.md
+++ b/charts/validator/README.md
@@ -1,6 +1,6 @@
 # validator
 
-![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.73.0](https://img.shields.io/badge/AppVersion-0.73.0-informational?style=flat-square)
+![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.73.0](https://img.shields.io/badge/AppVersion-0.73.0-informational?style=flat-square)
 
 A Helm chart for deploying Chronicle Validator on Kubernetes
 
@@ -16,16 +16,19 @@ A Helm chart for deploying Chronicle Validator on Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | extraObjects | list | `[]` | Extra K8s manifests to deploy |
-| ghost | object | `{"argsOverride":[],"commandOverride":[],"env":{"normal":{},"raw":{}},"ethConfig":{},"image":{"repository":null,"tag":null},"rpcUrl":null,"service":{"annotations":{},"ports":{"libp2p":{"port":8000,"protocol":"TCP"}},"type":"LoadBalancer"},"watchdogConfigReg":"0x94Fea534aef6df5cF66C2DAE5CE0A05d10C068F3"}` | Values for Ghost |
+| ghost | object | `{"argsOverride":[],"commandOverride":[],"env":{"normal":{},"raw":{}},"ethConfig":{},"image":{"repository":null,"tag":null},"rpcUrl":null,"service":{"annotations":{},"externalTrafficPolicy":"","loadBalancerClass":"","ports":{"libp2p":{"port":8000,"protocol":"TCP"}},"trafficDistribution":"","type":"LoadBalancer"},"watchdogConfigReg":"0x94Fea534aef6df5cF66C2DAE5CE0A05d10C068F3"}` | Values for Ghost |
 | ghost.argsOverride | list | `[]` | args override for the validator |
 | ghost.commandOverride | list | `[]` | command override for the validator |
 | ghost.env | object | `{"normal":{},"raw":{}}` | Environment variable listing |
 | ghost.env.normal | object | `{}` | un-encrypted env vars passed to the pod |
 | ghost.ethConfig | object | `{}` | Provide ETH keys from existing secrets : **NB** use only existing secret OR env vars, do not provide both |
 | ghost.image | object | `{"repository":null,"tag":null}` | Image tag for the validator (overrides global image if set) |
-| ghost.service | object | `{"annotations":{},"ports":{"libp2p":{"port":8000,"protocol":"TCP"}},"type":"LoadBalancer"}` | Service type for the validator |
+| ghost.service | object | `{"annotations":{},"externalTrafficPolicy":"","loadBalancerClass":"","ports":{"libp2p":{"port":8000,"protocol":"TCP"}},"trafficDistribution":"","type":"LoadBalancer"}` | Service type for the validator |
 | ghost.service.annotations | object | `{}` | Annotations to add to the service |
+| ghost.service.externalTrafficPolicy | string | `""` | Optional LoadBalancer traffic policy, for example Local. |
+| ghost.service.loadBalancerClass | string | `""` | Optional LoadBalancer class, for example service.k8s.aws/nlb. |
 | ghost.service.ports.libp2p | object | `{"port":8000,"protocol":"TCP"}` | libp2p port for the validator service |
+| ghost.service.trafficDistribution | string | `""` | Optional Kubernetes Service traffic distribution hint, for example PreferSameZone. |
 | ghost.service.type | string | `"LoadBalancer"` | Type of service for the validator, only `LoadBalancer` supported for now |
 | ghost.watchdogConfigReg | string | `"0x94Fea534aef6df5cF66C2DAE5CE0A05d10C068F3"` | WATCHDOG onchain config address |
 | global | object | `{"affinity":{},"chainId":1,"chainName":"eth","chainTxType":"eip1559","fullnameOverride":"ghost","image":{"pullPolicy":"Always","repository":"ghcr.io/chronicleprotocol/ghost","tag":""},"imagePullSecrets":[],"liveness":{"enabled":true,"livenessProbe":{"failureThreshold":4,"httpGet":{"path":"/healthz","port":9100},"initialDelaySeconds":60,"periodSeconds":60}},"logFormat":"text","logLevel":"info","metrics":{"enabled":true,"port":9090},"nameOverride":"","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"readiness":{"enabled":true,"readinessProbe":{"failureThreshold":4,"httpGet":{"path":"/healthz","port":9100},"initialDelaySeconds":60,"periodSeconds":60}},"replicaCount":1,"resources":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"tolerations":[],"topologySpreadConstraints":[]}` | Global values for the validator chart, values are used across the chart resources |
@@ -72,9 +75,12 @@ A Helm chart for deploying Chronicle Validator on Kubernetes
 | vao.extraVolumes | list | `[]` | Extra volumes to mount (typically for secrets) |
 | vao.image | object | `{"repository":null,"tag":null}` | Image tag for the validator (overrides global image if set) |
 | vao.resources | object | `{}` | Resources constraints for the validator, CPU, Memory, etc. |
-| vao.service | object | `{"annotations":{},"ports":{"libp2p":{"port":8001,"protocol":"TCP"}},"type":"LoadBalancer"}` | Service type for the validator |
+| vao.service | object | `{"annotations":{},"externalTrafficPolicy":"","loadBalancerClass":"","ports":{"libp2p":{"port":8001,"protocol":"TCP"}},"trafficDistribution":"","type":"LoadBalancer"}` | Service type for the validator |
 | vao.service.annotations | object | `{}` | Annotations to add to the service |
+| vao.service.externalTrafficPolicy | string | `""` | Optional LoadBalancer traffic policy, for example Local. |
+| vao.service.loadBalancerClass | string | `""` | Optional LoadBalancer class, for example service.k8s.aws/nlb. |
 | vao.service.ports.libp2p | object | `{"port":8001,"protocol":"TCP"}` | libp2p port for the validator service |
+| vao.service.trafficDistribution | string | `""` | Optional Kubernetes Service traffic distribution hint, for example PreferSameZone. |
 | vao.service.type | string | `"LoadBalancer"` | Type of service for the validator, only `LoadBalancer` supported for now |
 | vao.watchdogConfigReg | string | `"0x064358f9b6428C51F80511D73AFEb3A9e5Cf0213"` | WATCHDOG onchain config address |
 

--- a/charts/validator/templates/service-vao.yaml
+++ b/charts/validator/templates/service-vao.yaml
@@ -10,6 +10,15 @@ metadata:
     {{- include "validatorVao.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.vao.service.type }}
+  {{- with .Values.vao.service.loadBalancerClass }}
+  loadBalancerClass: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.vao.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.vao.service.trafficDistribution }}
+  trafficDistribution: {{ . | quote }}
+  {{- end }}
   ports:
     {{- range $key, $val := .Values.vao.service.ports }}
     - port: {{ $val.port }}

--- a/charts/validator/templates/service.yaml
+++ b/charts/validator/templates/service.yaml
@@ -10,6 +10,15 @@ metadata:
     {{- include "validator.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.ghost.service.type }}
+  {{- with .Values.ghost.service.loadBalancerClass }}
+  loadBalancerClass: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ghost.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ghost.service.trafficDistribution }}
+  trafficDistribution: {{ . | quote }}
+  {{- end }}
   ports:
     {{- range $key, $val := .Values.ghost.service.ports }}
     - port: {{ $val.port }}

--- a/charts/validator/values.yaml
+++ b/charts/validator/values.yaml
@@ -181,6 +181,12 @@ ghost:
   service:
     # -- Type of service for the validator, only `LoadBalancer` supported for now
     type: LoadBalancer
+    # -- Optional LoadBalancer class, for example service.k8s.aws/nlb.
+    loadBalancerClass: ""
+    # -- Optional LoadBalancer traffic policy, for example Local.
+    externalTrafficPolicy: ""
+    # -- Optional Kubernetes Service traffic distribution hint, for example PreferSameZone.
+    trafficDistribution: ""
 
     ports:
       # -- libp2p port for the validator service
@@ -254,6 +260,12 @@ vao:
   service:
     # -- Type of service for the validator, only `LoadBalancer` supported for now
     type: LoadBalancer
+    # -- Optional LoadBalancer class, for example service.k8s.aws/nlb.
+    loadBalancerClass: ""
+    # -- Optional LoadBalancer traffic policy, for example Local.
+    externalTrafficPolicy: ""
+    # -- Optional Kubernetes Service traffic distribution hint, for example PreferSameZone.
+    trafficDistribution: ""
 
     ports:
       # -- libp2p port for the validator service


### PR DESCRIPTION
## Summary

Adds chart interfaces for topology-aware Kubernetes Service controls:

- eRPC Service `trafficDistribution` support.
- spire Service support for `loadBalancerClass`, `externalTrafficPolicy`, and `trafficDistribution`.
- validator ghost/VAO Service support for `loadBalancerClass`, `externalTrafficPolicy`, and `trafficDistribution`.
- spire optional private `metricsService` so metrics can stay on ClusterIP while public LoadBalancer Services expose only libp2p.

This PR is the chart dependency for the app-of-apps rollout PR. Deployment rationale and operational baselines live in internal tracking.

## Verification

- `helm lint charts/erpc`
- `helm lint charts/spire`
- `helm lint charts/validator`
- `helm template erpc-test charts/erpc --set service.trafficDistribution=PreferSameZone`
- `helm template spire-test charts/spire --set service.type=LoadBalancer --set service.loadBalancerClass=service.k8s.aws/nlb --set service.externalTrafficPolicy=Local --set service.trafficDistribution=PreferSameZone --set metricsService.enabled=true --set serviceMonitor.enabled=true`
- `helm template validator-test charts/validator --set ghost.service.loadBalancerClass=service.k8s.aws/nlb --set ghost.service.externalTrafficPolicy=Local --set ghost.service.trafficDistribution=PreferSameZone --set vao.service.loadBalancerClass=service.k8s.aws/nlb --set vao.service.externalTrafficPolicy=Local --set vao.service.trafficDistribution=PreferSameZone`
- `ct lint --config ct.yaml`
